### PR TITLE
Revert "Create LocalCollisionAvoidance trait to allow different implementations of avoidance"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "landmass"
-version = "0.1.0"
+version = "0.1.1"
 
 description = "A navigation system for video game characters to walk around levels."
 


### PR DESCRIPTION
This was a bad idea. It prevented Archipelago from being Send + Sync, and once that restriction was added, the test broke anyway. I'll have to rethink this.

Also bumps to v0.1.1.