### PR TITLE
Pass ValidNavigationMesh to Islands as Arcs.

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -122,7 +122,7 @@ impl Agent {
 
 #[cfg(test)]
 mod tests {
-  use std::f32::consts::PI;
+  use std::{f32::consts::PI, sync::Arc};
 
   use glam::Vec3;
 
@@ -142,7 +142,9 @@ mod tests {
     let mut archipelago = Archipelago::new();
     let island_id = archipelago.add_island(nav_mesh.mesh_bounds);
     archipelago.get_island_mut(island_id).set_nav_mesh(
-      transform, nav_mesh, /* linkable_distance_to_region_edge= */ 0.01,
+      transform,
+      Arc::new(nav_mesh),
+      /* linkable_distance_to_region_edge= */ 0.01,
     );
     let mut agent = Agent::create(
       /* position= */ transform.apply(Vec3::new(1.0, 0.0, 1.0)),
@@ -212,7 +214,9 @@ mod tests {
     let mut archipelago = Archipelago::new();
     let island_id = archipelago.add_island(nav_mesh.mesh_bounds);
     archipelago.get_island_mut(island_id).set_nav_mesh(
-      transform, nav_mesh, /* linkable_distance_to_region_edge= */ 0.01,
+      transform,
+      Arc::new(nav_mesh),
+      /* linkable_distance_to_region_edge= */ 0.01,
     );
 
     let mut agent = Agent::create(

--- a/src/avoidance.rs
+++ b/src/avoidance.rs
@@ -272,7 +272,7 @@ fn nav_mesh_borders_to_dodgy_obstacles(
 
 #[cfg(test)]
 mod tests {
-  use std::collections::HashMap;
+  use std::{collections::HashMap, sync::Arc};
 
   use glam::{Vec2, Vec3};
 
@@ -352,7 +352,7 @@ mod tests {
       let mut island = Island::new(nav_mesh.mesh_bounds);
       island.set_nav_mesh(
         Transform { translation: Vec3::ZERO, rotation: 0.0 },
-        nav_mesh,
+        Arc::new(nav_mesh),
         /* linkable_distance_to_region_edge= */ 0.01,
       );
       island
@@ -409,7 +409,7 @@ mod tests {
       let mut island = Island::new(nav_mesh.mesh_bounds);
       island.set_nav_mesh(
         Transform { translation: Vec3::ZERO, rotation: 0.0 },
-        nav_mesh,
+        Arc::new(nav_mesh),
         /* linkable_distance_to_region_edge= */ 0.01,
       );
       island
@@ -556,7 +556,7 @@ mod tests {
       let mut island = Island::new(nav_mesh.mesh_bounds);
       island.set_nav_mesh(
         Transform { translation: Vec3::ZERO, rotation: 0.0 },
-        nav_mesh,
+        Arc::new(nav_mesh),
         /* linkable_distance_to_region_edge= */ 0.01,
       );
       island
@@ -670,7 +670,7 @@ mod tests {
       let mut island = Island::new(nav_mesh.mesh_bounds);
       island.set_nav_mesh(
         Transform { translation: Vec3::ZERO, rotation: 0.0 },
-        nav_mesh,
+        Arc::new(nav_mesh),
         /* linkable_distance_to_region_edge= */ 0.01,
       );
       island
@@ -759,7 +759,7 @@ mod tests {
       let mut island = Island::new(nav_mesh.mesh_bounds);
       island.set_nav_mesh(
         Transform { translation: Vec3::ZERO, rotation: 0.0 },
-        nav_mesh,
+        Arc::new(nav_mesh),
         /* linkable_distance_to_region_edge= */ 0.01,
       );
       island

--- a/src/island.rs
+++ b/src/island.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::{
   nav_mesh::MeshEdgeRef, util::Transform, BoundingBox, ValidNavigationMesh,
 };
@@ -22,7 +24,7 @@ pub(crate) struct IslandNavigationData {
   // The transform from the Island's frame to the Archipelago's frame.
   pub transform: Transform,
   // The navigation mesh for the island.
-  pub nav_mesh: ValidNavigationMesh,
+  pub nav_mesh: Arc<ValidNavigationMesh>,
   // The edges in `nav_mesh` that can be linked with other adjacent islands.
   pub linkable_edges: [Vec<MeshEdgeRef>; 6],
 }
@@ -37,10 +39,18 @@ impl Island {
     }
   }
 
+  pub fn get_transform(&self) -> Option<Transform> {
+    self.nav_data.as_ref().map(|d| d.transform)
+  }
+
+  pub fn get_nav_mesh(&self) -> Option<Arc<ValidNavigationMesh>> {
+    self.nav_data.as_ref().map(|d| Arc::clone(&d.nav_mesh))
+  }
+
   pub fn set_nav_mesh(
     &mut self,
     transform: Transform,
-    nav_mesh: ValidNavigationMesh,
+    nav_mesh: Arc<ValidNavigationMesh>,
     linkable_distance_to_region_edge: f32,
   ) {
     self.nav_data = Some(IslandNavigationData {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ be confusing.
 ```
 use glam::Vec3;
 use landmass::*;
+use std::sync::Arc;
 
 let mut archipelago = Archipelago::new();
 
@@ -64,7 +65,9 @@ let nav_mesh = NavigationMesh {
   polygons: vec![vec![0, 1, 2, 3]],
 };
 
-let valid_nav_mesh = nav_mesh.validate().expect("Validation succeeds");
+let valid_nav_mesh = Arc::new(
+  nav_mesh.validate().expect("Validation succeeds")
+);
 
 let island_id = archipelago.add_island(valid_nav_mesh.get_bounds());
 archipelago
@@ -438,7 +441,7 @@ fn does_agent_need_repath(
 
 #[cfg(test)]
 mod tests {
-  use std::collections::HashMap;
+  use std::{collections::HashMap, sync::Arc};
 
   use glam::Vec3;
 
@@ -558,13 +561,15 @@ mod tests {
       let mut island = Island::new(BoundingBox::new_box(Vec3::ZERO, Vec3::ONE));
       island.set_nav_mesh(
         Transform::default(),
-        NavigationMesh {
-          mesh_bounds: None,
-          vertices: vec![],
-          polygons: vec![],
-        }
-        .validate()
-        .expect("is valid"),
+        Arc::new(
+          NavigationMesh {
+            mesh_bounds: None,
+            vertices: vec![],
+            polygons: vec![],
+          }
+          .validate()
+          .expect("is valid"),
+        ),
         /* linkable_distance_to_region_edge= */ 0.01,
       );
       island
@@ -731,7 +736,7 @@ mod tests {
     let island_id = archipelago.add_island(nav_mesh.mesh_bounds);
     archipelago.get_island_mut(island_id).set_nav_mesh(
       Transform { translation: Vec3::ZERO, rotation: 0.0 },
-      nav_mesh,
+      Arc::new(nav_mesh),
       /* linkable_distance_to_region_edge= */ 0.01,
     );
 

--- a/src/nav_data.rs
+++ b/src/nav_data.rs
@@ -67,7 +67,7 @@ impl NavigationData {
 
 #[cfg(test)]
 mod tests {
-  use std::{collections::HashMap, f32::consts::PI};
+  use std::{collections::HashMap, f32::consts::PI, sync::Arc};
 
   use glam::Vec3;
 
@@ -96,20 +96,21 @@ mod tests {
     }
     .validate()
     .expect("is valid");
+    let nav_mesh = Arc::new(nav_mesh);
 
     let mut islands = HashMap::new();
 
     let mut island_1 = Island::new(BoundingBox::new_box(Vec3::ZERO, Vec3::ONE));
     island_1.set_nav_mesh(
       Transform { translation: Vec3::ZERO, rotation: 0.0 },
-      nav_mesh.clone(),
+      Arc::clone(&nav_mesh),
       /* linkable_distance_to_region_edge= */ 0.01,
     );
 
     let mut island_2 = Island::new(BoundingBox::new_box(Vec3::ZERO, Vec3::ONE));
     island_2.set_nav_mesh(
       Transform { translation: Vec3::new(5.0, 0.1, 0.0), rotation: PI * -0.5 },
-      nav_mesh.clone(),
+      Arc::clone(&nav_mesh),
       /* linkable_distance_to_region_edge= */ 0.01,
     );
 

--- a/src/path.rs
+++ b/src/path.rs
@@ -105,7 +105,7 @@ impl Path {
 
 #[cfg(test)]
 mod tests {
-  use std::{collections::HashMap, f32::consts::PI};
+  use std::{collections::HashMap, f32::consts::PI, sync::Arc};
 
   use glam::Vec3;
 
@@ -176,7 +176,9 @@ mod tests {
     let mut archipelago = Archipelago::new();
     let island_id = archipelago.add_island(nav_mesh.mesh_bounds);
     archipelago.get_island_mut(island_id).set_nav_mesh(
-      transform, nav_mesh, /* linkable_distance_to_region_edge= */ 0.01,
+      transform,
+      Arc::new(nav_mesh),
+      /* linkable_distance_to_region_edge= */ 0.01,
     );
 
     let path = Path {
@@ -266,7 +268,9 @@ mod tests {
     let mut archipelago = Archipelago::new();
     let island_id = archipelago.add_island(nav_mesh.mesh_bounds);
     archipelago.get_island_mut(island_id).set_nav_mesh(
-      transform, nav_mesh, /* linkable_distance_to_region_edge= */ 0.01,
+      transform,
+      Arc::new(nav_mesh),
+      /* linkable_distance_to_region_edge= */ 0.01,
     );
 
     let path = Path {
@@ -329,7 +333,7 @@ mod tests {
     let island_id = archipelago.add_island(nav_mesh.mesh_bounds);
     archipelago.get_island_mut(island_id).set_nav_mesh(
       Transform { translation: Vec3::ZERO, rotation: 0.0 },
-      nav_mesh,
+      Arc::new(nav_mesh),
       /* linkable_distance_to_region_edge= */ 0.01,
     );
 
@@ -372,18 +376,19 @@ mod tests {
       polygons: vec![],
       vertices: vec![],
     };
+    let nav_mesh = Arc::new(nav_mesh);
 
     let mut island_1 = Island::new(BoundingBox::new_box(Vec3::ZERO, Vec3::ONE));
     island_1.set_nav_mesh(
       Transform::default(),
-      nav_mesh.clone(),
+      Arc::clone(&nav_mesh),
       /* linkable_distance_to_region_edge= */ 0.01,
     );
 
     let mut island_3 = Island::new(BoundingBox::new_box(Vec3::ZERO, Vec3::ONE));
     island_3.set_nav_mesh(
       Transform::default(),
-      nav_mesh.clone(),
+      Arc::clone(&nav_mesh),
       /* linkable_distance_to_region_edge= */ 0.01,
     );
 

--- a/src/pathfinding.rs
+++ b/src/pathfinding.rs
@@ -114,7 +114,7 @@ pub(crate) fn find_path(
 
 #[cfg(test)]
 mod tests {
-  use std::f32::consts::PI;
+  use std::{f32::consts::PI, sync::Arc};
 
   use glam::Vec3;
 
@@ -160,7 +160,7 @@ mod tests {
     let island_id = archipelago.add_island(nav_mesh.mesh_bounds);
     archipelago.get_island_mut(island_id).set_nav_mesh(
       Transform { translation: Vec3::ZERO, rotation: 0.0 },
-      nav_mesh,
+      Arc::new(nav_mesh),
       /* linkable_distance_to_region_edge= */ 0.01,
     );
 
@@ -254,19 +254,20 @@ mod tests {
     }
     .validate()
     .expect("Mesh is valid.");
+    let nav_mesh = Arc::new(nav_mesh);
 
     let mut archipelago = Archipelago::new();
     let island_id_1 = archipelago.add_island(nav_mesh.mesh_bounds);
     archipelago.get_island_mut(island_id_1).set_nav_mesh(
       Transform { translation: Vec3::ZERO, rotation: 0.0 },
-      nav_mesh.clone(),
+      Arc::clone(&nav_mesh),
       /* linkable_distance_to_region_edge= */ 0.01,
     );
 
     let island_id_2 = archipelago.add_island(nav_mesh.mesh_bounds);
     archipelago.get_island_mut(island_id_2).set_nav_mesh(
       Transform { translation: Vec3::new(6.0, 0.0, 0.0), rotation: PI * 0.5 },
-      nav_mesh,
+      Arc::clone(&nav_mesh),
       /* linkable_distance_to_region_edge= */ 0.01,
     );
 
@@ -341,19 +342,20 @@ mod tests {
     }
     .validate()
     .expect("Mesh is valid.");
+    let nav_mesh = Arc::new(nav_mesh);
 
     let mut archipelago = Archipelago::new();
     let island_id_1 = archipelago.add_island(nav_mesh.mesh_bounds);
     archipelago.get_island_mut(island_id_1).set_nav_mesh(
       Transform { translation: Vec3::ZERO, rotation: 0.0 },
-      nav_mesh.clone(),
+      Arc::clone(&nav_mesh),
       /* linkable_distance_to_region_edge= */ 0.01,
     );
 
     let island_id_2 = archipelago.add_island(nav_mesh.mesh_bounds);
     archipelago.get_island_mut(island_id_2).set_nav_mesh(
       Transform { translation: Vec3::new(6.0, 0.0, 0.0), rotation: PI * 0.5 },
-      nav_mesh,
+      Arc::clone(&nav_mesh),
       /* linkable_distance_to_region_edge= */ 0.01,
     );
 


### PR DESCRIPTION
It sucks that we have to use Arcs, but this is an easy way to allow us to compare nav meshes, and allows callers to keep their own copy to check for deltas.