### PR TITLE
Simplify creating islands

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -140,12 +140,10 @@ mod tests {
     let transform =
       Transform { translation: Vec3::new(2.0, 3.0, 4.0), rotation: PI * 0.85 };
     let mut archipelago = Archipelago::new();
-    let island_id = archipelago.add_island(nav_mesh.mesh_bounds);
-    archipelago.get_island_mut(island_id).set_nav_mesh(
-      transform,
-      Arc::new(nav_mesh),
-      /* linkable_distance_to_region_edge= */ 0.01,
-    );
+    let island_id = archipelago.add_island();
+    archipelago
+      .get_island_mut(island_id)
+      .set_nav_mesh(transform, Arc::new(nav_mesh));
     let mut agent = Agent::create(
       /* position= */ transform.apply(Vec3::new(1.0, 0.0, 1.0)),
       /* velocity= */ Vec3::ZERO,
@@ -212,12 +210,10 @@ mod tests {
     let transform =
       Transform { translation: Vec3::new(2.0, 3.0, 4.0), rotation: PI * 0.85 };
     let mut archipelago = Archipelago::new();
-    let island_id = archipelago.add_island(nav_mesh.mesh_bounds);
-    archipelago.get_island_mut(island_id).set_nav_mesh(
-      transform,
-      Arc::new(nav_mesh),
-      /* linkable_distance_to_region_edge= */ 0.01,
-    );
+    let island_id = archipelago.add_island();
+    archipelago
+      .get_island_mut(island_id)
+      .set_nav_mesh(transform, Arc::new(nav_mesh));
 
     let mut agent = Agent::create(
       /* position= */ Vec3::ZERO,

--- a/src/avoidance.rs
+++ b/src/avoidance.rs
@@ -349,11 +349,10 @@ mod tests {
 
     let mut nav_data = NavigationData::new();
     nav_data.islands.insert(1, {
-      let mut island = Island::new(nav_mesh.mesh_bounds);
+      let mut island = Island::new();
       island.set_nav_mesh(
         Transform { translation: Vec3::ZERO, rotation: 0.0 },
         Arc::new(nav_mesh),
-        /* linkable_distance_to_region_edge= */ 0.01,
       );
       island
     });
@@ -406,11 +405,10 @@ mod tests {
 
     let mut nav_data = NavigationData::new();
     nav_data.islands.insert(1, {
-      let mut island = Island::new(nav_mesh.mesh_bounds);
+      let mut island = Island::new();
       island.set_nav_mesh(
         Transform { translation: Vec3::ZERO, rotation: 0.0 },
         Arc::new(nav_mesh),
-        /* linkable_distance_to_region_edge= */ 0.01,
       );
       island
     });
@@ -553,11 +551,10 @@ mod tests {
 
     let mut nav_data = NavigationData::new();
     nav_data.islands.insert(1, {
-      let mut island = Island::new(nav_mesh.mesh_bounds);
+      let mut island = Island::new();
       island.set_nav_mesh(
         Transform { translation: Vec3::ZERO, rotation: 0.0 },
         Arc::new(nav_mesh),
-        /* linkable_distance_to_region_edge= */ 0.01,
       );
       island
     });
@@ -667,11 +664,10 @@ mod tests {
 
     let mut nav_data = NavigationData::new();
     nav_data.islands.insert(1, {
-      let mut island = Island::new(nav_mesh.mesh_bounds);
+      let mut island = Island::new();
       island.set_nav_mesh(
         Transform { translation: Vec3::ZERO, rotation: 0.0 },
         Arc::new(nav_mesh),
-        /* linkable_distance_to_region_edge= */ 0.01,
       );
       island
     });
@@ -756,11 +752,10 @@ mod tests {
 
     let mut nav_data = NavigationData::new();
     nav_data.islands.insert(1, {
-      let mut island = Island::new(nav_mesh.mesh_bounds);
+      let mut island = Island::new();
       island.set_nav_mesh(
         Transform { translation: Vec3::ZERO, rotation: 0.0 },
         Arc::new(nav_mesh),
-        /* linkable_distance_to_region_edge= */ 0.01,
       );
       island
     });

--- a/src/avoidance.rs
+++ b/src/avoidance.rs
@@ -347,7 +347,7 @@ mod tests {
     .validate()
     .expect("Validation succeeds");
 
-    let mut nav_data = NavigationData { islands: HashMap::new() };
+    let mut nav_data = NavigationData::new();
     nav_data.islands.insert(1, {
       let mut island = Island::new(nav_mesh.mesh_bounds);
       island.set_nav_mesh(
@@ -404,7 +404,7 @@ mod tests {
     .validate()
     .expect("Validation succeeds");
 
-    let mut nav_data = NavigationData { islands: HashMap::new() };
+    let mut nav_data = NavigationData::new();
     nav_data.islands.insert(1, {
       let mut island = Island::new(nav_mesh.mesh_bounds);
       island.set_nav_mesh(
@@ -551,7 +551,7 @@ mod tests {
     .validate()
     .expect("Validation succeeds");
 
-    let mut nav_data = NavigationData { islands: HashMap::new() };
+    let mut nav_data = NavigationData::new();
     nav_data.islands.insert(1, {
       let mut island = Island::new(nav_mesh.mesh_bounds);
       island.set_nav_mesh(
@@ -665,7 +665,7 @@ mod tests {
     .validate()
     .expect("Validation succeeded.");
 
-    let mut nav_data = NavigationData { islands: HashMap::new() };
+    let mut nav_data = NavigationData::new();
     nav_data.islands.insert(1, {
       let mut island = Island::new(nav_mesh.mesh_bounds);
       island.set_nav_mesh(
@@ -754,7 +754,7 @@ mod tests {
     .validate()
     .expect("Validation succeeded.");
 
-    let mut nav_data = NavigationData { islands: HashMap::new() };
+    let mut nav_data = NavigationData::new();
     nav_data.islands.insert(1, {
       let mut island = Island::new(nav_mesh.mesh_bounds);
       island.set_nav_mesh(

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -298,12 +298,11 @@ mod tests {
     .expect("Mesh is valid.");
 
     let mut archipelago = Archipelago::new();
-    let island_id = archipelago.add_island(nav_mesh.mesh_bounds);
+    let island_id = archipelago.add_island();
     const TRANSLATION: Vec3 = Vec3::ONE;
     archipelago.get_island_mut(island_id).set_nav_mesh(
       Transform { translation: TRANSLATION, rotation: 0.0 },
       Arc::new(nav_mesh),
-      /* linkable_distance_to_region_edge= */ 0.01,
     );
 
     let agent_id = archipelago.add_agent(Agent::create(

--- a/src/island.rs
+++ b/src/island.rs
@@ -1,18 +1,12 @@
 use std::sync::Arc;
 
-use crate::{
-  nav_mesh::MeshEdgeRef, util::Transform, BoundingBox, ValidNavigationMesh,
-};
+use crate::{util::Transform, ValidNavigationMesh};
 
 pub type IslandId = u32;
 
 // An Island in an Archipelago. Islands are the region that an navigation mesh
 // can be put into.
 pub struct Island {
-  // The bounding box that this island is responsible for. For tiled worlds,
-  // this should be the bounding box of the tile. In other cases, it is usually
-  // the bounding box of the navigation mesh.
-  pub(crate) region_bounds: BoundingBox,
   // The navigation data, if present. May be missing for islands that have not
   // finished loading yet, or are having their data updated.
   pub(crate) nav_data: Option<IslandNavigationData>,
@@ -25,14 +19,11 @@ pub(crate) struct IslandNavigationData {
   pub transform: Transform,
   // The navigation mesh for the island.
   pub nav_mesh: Arc<ValidNavigationMesh>,
-  // The edges in `nav_mesh` that can be linked with other adjacent islands.
-  pub linkable_edges: [Vec<MeshEdgeRef>; 6],
 }
 
 impl Island {
-  pub(crate) fn new(region_bounds: BoundingBox) -> Self {
+  pub(crate) fn new() -> Self {
     Self {
-      region_bounds,
       nav_data: None,
       // The island is dirty in case an island is removed then added back.
       dirty: true,
@@ -51,17 +42,8 @@ impl Island {
     &mut self,
     transform: Transform,
     nav_mesh: Arc<ValidNavigationMesh>,
-    linkable_distance_to_region_edge: f32,
   ) {
-    self.nav_data = Some(IslandNavigationData {
-      linkable_edges: nav_mesh.find_linkable_edges(
-        self.region_bounds,
-        transform,
-        linkable_distance_to_region_edge,
-      ),
-      transform,
-      nav_mesh,
-    });
+    self.nav_data = Some(IslandNavigationData { transform, nav_mesh });
     self.dirty = true;
   }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,7 +184,7 @@ impl Default for AgentOptions {
 impl Archipelago {
   pub fn new() -> Self {
     Self {
-      nav_data: NavigationData { islands: HashMap::new() },
+      nav_data: NavigationData::new(),
       agent_options: AgentOptions::default(),
       agents: HashMap::new(),
     }
@@ -451,7 +451,7 @@ fn does_agent_need_repath(
 
 #[cfg(test)]
 mod tests {
-  use std::{collections::HashMap, sync::Arc};
+  use std::sync::Arc;
 
   use glam::Vec3;
 
@@ -473,7 +473,7 @@ mod tests {
       /* max_velocity= */ 0.0,
     );
 
-    let nav_data = NavigationData { islands: HashMap::new() };
+    let nav_data = NavigationData::new();
 
     assert_eq!(
       does_agent_need_repath(&agent, None, None, &nav_data),
@@ -499,7 +499,7 @@ mod tests {
     );
     agent.current_target = Some(Vec3::ZERO);
 
-    let nav_data = NavigationData { islands: HashMap::new() };
+    let nav_data = NavigationData::new();
 
     assert_eq!(
       does_agent_need_repath(
@@ -532,7 +532,7 @@ mod tests {
     );
     agent.current_target = Some(Vec3::ZERO);
 
-    let mut nav_data = NavigationData { islands: HashMap::new() };
+    let mut nav_data = NavigationData::new();
 
     // No path.
     assert_eq!(

--- a/src/nav_data.rs
+++ b/src/nav_data.rs
@@ -76,8 +76,7 @@ mod tests {
   use glam::Vec3;
 
   use crate::{
-    island::Island, nav_data::NodeRef, nav_mesh::NavigationMesh, BoundingBox,
-    Transform,
+    island::Island, nav_data::NodeRef, nav_mesh::NavigationMesh, Transform,
   };
 
   use super::NavigationData;
@@ -104,18 +103,16 @@ mod tests {
 
     let mut islands = HashMap::new();
 
-    let mut island_1 = Island::new(BoundingBox::new_box(Vec3::ZERO, Vec3::ONE));
+    let mut island_1 = Island::new();
     island_1.set_nav_mesh(
       Transform { translation: Vec3::ZERO, rotation: 0.0 },
       Arc::clone(&nav_mesh),
-      /* linkable_distance_to_region_edge= */ 0.01,
     );
 
-    let mut island_2 = Island::new(BoundingBox::new_box(Vec3::ZERO, Vec3::ONE));
+    let mut island_2 = Island::new();
     island_2.set_nav_mesh(
       Transform { translation: Vec3::new(5.0, 0.1, 0.0), rotation: PI * -0.5 },
       Arc::clone(&nav_mesh),
-      /* linkable_distance_to_region_edge= */ 0.01,
     );
 
     islands.insert(1, island_1);

--- a/src/nav_data.rs
+++ b/src/nav_data.rs
@@ -17,6 +17,10 @@ pub struct NodeRef {
 }
 
 impl NavigationData {
+  pub fn new() -> Self {
+    Self { islands: HashMap::new() }
+  }
+
   pub fn sample_point(
     &self,
     point: Vec3,
@@ -117,7 +121,8 @@ mod tests {
     islands.insert(1, island_1);
     islands.insert(2, island_2);
 
-    let nav_data = NavigationData { islands };
+    let mut nav_data = NavigationData::new();
+    nav_data.islands = islands;
     // Just above island 1 node.
     assert_eq!(
       nav_data.sample_point(

--- a/src/path.rs
+++ b/src/path.rs
@@ -174,12 +174,10 @@ mod tests {
     let transform =
       Transform { translation: Vec3::new(5.0, 7.0, 9.0), rotation: PI * 0.35 };
     let mut archipelago = Archipelago::new();
-    let island_id = archipelago.add_island(nav_mesh.mesh_bounds);
-    archipelago.get_island_mut(island_id).set_nav_mesh(
-      transform,
-      Arc::new(nav_mesh),
-      /* linkable_distance_to_region_edge= */ 0.01,
-    );
+    let island_id = archipelago.add_island();
+    archipelago
+      .get_island_mut(island_id)
+      .set_nav_mesh(transform, Arc::new(nav_mesh));
 
     let path = Path {
       corridor: vec![
@@ -266,12 +264,10 @@ mod tests {
       rotation: PI * 1.8,
     };
     let mut archipelago = Archipelago::new();
-    let island_id = archipelago.add_island(nav_mesh.mesh_bounds);
-    archipelago.get_island_mut(island_id).set_nav_mesh(
-      transform,
-      Arc::new(nav_mesh),
-      /* linkable_distance_to_region_edge= */ 0.01,
-    );
+    let island_id = archipelago.add_island();
+    archipelago
+      .get_island_mut(island_id)
+      .set_nav_mesh(transform, Arc::new(nav_mesh));
 
     let path = Path {
       corridor: vec![
@@ -330,11 +326,10 @@ mod tests {
     .expect("Mesh is valid.");
 
     let mut archipelago = Archipelago::new();
-    let island_id = archipelago.add_island(nav_mesh.mesh_bounds);
+    let island_id = archipelago.add_island();
     archipelago.get_island_mut(island_id).set_nav_mesh(
       Transform { translation: Vec3::ZERO, rotation: 0.0 },
       Arc::new(nav_mesh),
-      /* linkable_distance_to_region_edge= */ 0.01,
     );
 
     let path = Path {
@@ -378,19 +373,11 @@ mod tests {
     };
     let nav_mesh = Arc::new(nav_mesh);
 
-    let mut island_1 = Island::new(BoundingBox::new_box(Vec3::ZERO, Vec3::ONE));
-    island_1.set_nav_mesh(
-      Transform::default(),
-      Arc::clone(&nav_mesh),
-      /* linkable_distance_to_region_edge= */ 0.01,
-    );
+    let mut island_1 = Island::new();
+    island_1.set_nav_mesh(Transform::default(), Arc::clone(&nav_mesh));
 
-    let mut island_3 = Island::new(BoundingBox::new_box(Vec3::ZERO, Vec3::ONE));
-    island_3.set_nav_mesh(
-      Transform::default(),
-      Arc::clone(&nav_mesh),
-      /* linkable_distance_to_region_edge= */ 0.01,
-    );
+    let mut island_3 = Island::new();
+    island_3.set_nav_mesh(Transform::default(), Arc::clone(&nav_mesh));
 
     // Pretend we updated the islands so they aren't dirty.
     island_1.dirty = false;
@@ -404,12 +391,8 @@ mod tests {
     nav_data.islands = islands;
     assert!(!path.is_valid(&nav_data));
 
-    let mut island_2 = Island::new(BoundingBox::new_box(Vec3::ZERO, Vec3::ONE));
-    island_2.set_nav_mesh(
-      Transform::default(),
-      nav_mesh,
-      /* linkable_distance_to_region_edge= */ 0.01,
-    );
+    let mut island_2 = Island::new();
+    island_2.set_nav_mesh(Transform::default(), nav_mesh);
 
     nav_data.islands.insert(2, island_2);
     assert!(!path.is_valid(&nav_data));

--- a/src/path.rs
+++ b/src/path.rs
@@ -400,7 +400,8 @@ mod tests {
     islands.insert(1, island_1);
     islands.insert(3, island_3);
 
-    let mut nav_data = NavigationData { islands };
+    let mut nav_data = NavigationData::new();
+    nav_data.islands = islands;
     assert!(!path.is_valid(&nav_data));
 
     let mut island_2 = Island::new(BoundingBox::new_box(Vec3::ZERO, Vec3::ONE));

--- a/src/pathfinding.rs
+++ b/src/pathfinding.rs
@@ -157,11 +157,10 @@ mod tests {
     .expect("Mesh is valid.");
 
     let mut archipelago = Archipelago::new();
-    let island_id = archipelago.add_island(nav_mesh.mesh_bounds);
+    let island_id = archipelago.add_island();
     archipelago.get_island_mut(island_id).set_nav_mesh(
       Transform { translation: Vec3::ZERO, rotation: 0.0 },
       Arc::new(nav_mesh),
-      /* linkable_distance_to_region_edge= */ 0.01,
     );
 
     let nav_data = &archipelago.nav_data;
@@ -257,18 +256,16 @@ mod tests {
     let nav_mesh = Arc::new(nav_mesh);
 
     let mut archipelago = Archipelago::new();
-    let island_id_1 = archipelago.add_island(nav_mesh.mesh_bounds);
+    let island_id_1 = archipelago.add_island();
     archipelago.get_island_mut(island_id_1).set_nav_mesh(
       Transform { translation: Vec3::ZERO, rotation: 0.0 },
       Arc::clone(&nav_mesh),
-      /* linkable_distance_to_region_edge= */ 0.01,
     );
 
-    let island_id_2 = archipelago.add_island(nav_mesh.mesh_bounds);
+    let island_id_2 = archipelago.add_island();
     archipelago.get_island_mut(island_id_2).set_nav_mesh(
       Transform { translation: Vec3::new(6.0, 0.0, 0.0), rotation: PI * 0.5 },
       Arc::clone(&nav_mesh),
-      /* linkable_distance_to_region_edge= */ 0.01,
     );
 
     let nav_data = &archipelago.nav_data;
@@ -345,18 +342,16 @@ mod tests {
     let nav_mesh = Arc::new(nav_mesh);
 
     let mut archipelago = Archipelago::new();
-    let island_id_1 = archipelago.add_island(nav_mesh.mesh_bounds);
+    let island_id_1 = archipelago.add_island();
     archipelago.get_island_mut(island_id_1).set_nav_mesh(
       Transform { translation: Vec3::ZERO, rotation: 0.0 },
       Arc::clone(&nav_mesh),
-      /* linkable_distance_to_region_edge= */ 0.01,
     );
 
-    let island_id_2 = archipelago.add_island(nav_mesh.mesh_bounds);
+    let island_id_2 = archipelago.add_island();
     archipelago.get_island_mut(island_id_2).set_nav_mesh(
       Transform { translation: Vec3::new(6.0, 0.0, 0.0), rotation: PI * 0.5 },
       Arc::clone(&nav_mesh),
-      /* linkable_distance_to_region_edge= */ 0.01,
     );
 
     let nav_data = &archipelago.nav_data;


### PR DESCRIPTION
Now islands don't need to care about what they're "responsible" for. We also don't need to specify the linkable_distance_to_region_edge per island - we can do it once for the entire Archipelago (which makes more sense).