### PR TITLE
Improve the performance and structure of connectivity data.

### DIFF
--- a/src/avoidance.rs
+++ b/src/avoidance.rs
@@ -176,19 +176,22 @@ fn nav_mesh_borders_to_dodgy_obstacles(
       nav_data.islands.get(&node.island_id).unwrap().nav_data.as_ref().unwrap();
 
     let polygon = &island_data.nav_mesh.polygons[node.polygon_index];
-    let connectivity = &island_data.nav_mesh.connectivity[node.polygon_index];
     let boundary_links = nav_data.boundary_links.get(&node);
     let modified_node = nav_data.modified_nodes.get(&node);
 
     let mut remaining_edges: HashSet<usize> =
       HashSet::from_iter(0..polygon.vertices.len());
-    for (vertex_1, vertex_2, node_ref) in connectivity
+    for (vertex_1, vertex_2, node_ref) in polygon
+      .connectivity
       .iter()
-      .map(|connectivity| {
-        remaining_edges.remove(&connectivity.edge_index);
+      .enumerate()
+      .filter_map(|(edge_index, conn)| {
+        conn.as_ref().map(|conn| (edge_index, conn))
+      })
+      .map(|(edge_index, connectivity)| {
+        remaining_edges.remove(&edge_index);
 
-        let (vertex_1, vertex_2) =
-          polygon.get_edge_indices(connectivity.edge_index);
+        let (vertex_1, vertex_2) = polygon.get_edge_indices(edge_index);
         (
           vertex_index_to_dodgy_vec(island_data, vertex_1, agent_point),
           vertex_index_to_dodgy_vec(island_data, vertex_2, agent_point),

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -57,12 +57,8 @@ pub fn draw_archipelago_debug(
       continue;
     };
 
-    for (polygon_index, (polygon, connectivity)) in nav_data
-      .nav_mesh
-      .polygons
-      .iter()
-      .zip(nav_data.nav_mesh.connectivity.iter())
-      .enumerate()
+    for (polygon_index, polygon) in
+      nav_data.nav_mesh.polygons.iter().enumerate()
     {
       let center_point = nav_data.transform.apply(polygon.center);
       for i in 0..polygon.vertices.len() {
@@ -81,7 +77,10 @@ pub fn draw_archipelago_debug(
         );
       }
 
-      for connection in connectivity.iter() {
+      for (edge_index, connection) in polygon.connectivity.iter().enumerate() {
+        let Some(connection) = connection.as_ref() else {
+          continue;
+        };
         // Ignore connections where the connected polygon has a greater index.
         // This prevents drawing the same edge multiple times by picking one of
         // the edges to draw.
@@ -89,7 +88,7 @@ pub fn draw_archipelago_debug(
           continue;
         }
 
-        let i = connection.edge_index;
+        let i = edge_index;
         let j = (i + 1) % polygon.vertices.len();
 
         let i = polygon.vertices[i];

--- a/src/lib_test.rs
+++ b/src/lib_test.rs
@@ -476,7 +476,6 @@ fn new_or_changed_island_is_not_dirty_after_update() {
     Arc::new(ValidNavigationMesh {
       mesh_bounds: BoundingBox::Empty,
       boundary_edges: vec![],
-      connectivity: vec![],
       polygons: vec![],
       vertices: vec![],
     }),

--- a/src/nav_data.rs
+++ b/src/nav_data.rs
@@ -272,13 +272,6 @@ impl NavigationData {
     };
 
     let polygon = &island_nav_data.nav_mesh.polygons[node_ref.polygon_index];
-    let connectivity =
-      &island_nav_data.nav_mesh.connectivity[node_ref.polygon_index];
-
-    let connected_edges = connectivity
-      .iter()
-      .map(|connectivity| connectivity.edge_index)
-      .collect::<HashSet<usize>>();
 
     fn vec2_to_coord(v: Vec2) -> Coord<f32> {
       Coord::from((v.x, v.y))
@@ -301,7 +294,7 @@ impl NavigationData {
     let mut current_line_string = vec![];
 
     for (i, vertex) in polygon.vertices.iter().copied().enumerate() {
-      if connected_edges.contains(&i) {
+      if polygon.connectivity[i].is_some() {
         if !current_line_string.is_empty() {
           let mut line_string = vec![];
           swap(&mut current_line_string, &mut line_string);

--- a/src/nav_mesh_test.rs
+++ b/src/nav_mesh_test.rs
@@ -1,4 +1,4 @@
-use glam::Vec3;
+use glam::{Vec2, Vec3};
 
 use crate::{
   nav_mesh::{Connectivity, MeshEdgeRef, ValidPolygon},
@@ -268,15 +268,24 @@ fn derives_connectivity_and_boundary_edges() {
     boundary_edge.polygon_index * 100 + boundary_edge.edge_index
   });
 
+  // Each edge has a cost of node 1 to its edge (always 0.5), and each other
+  // node to its edge.
+  let cost_01 =
+    0.5 + Vec2::new(2.0 / 3.0, 1.0 / 3.0).distance(Vec2::new(1.0, 0.5));
+  let cost_12 =
+    0.5 + Vec3::new(2.5, 0.5, 0.5).distance(Vec3::new(2.0, 0.0, 0.5));
+  let cost_13 =
+    0.5 + Vec3::new(1.5, 0.5, 1.5).distance(Vec3::new(1.5, 0.0, 1.0));
+
   let expected_connectivity: [&[_]; 4] = [
-    &[Connectivity { edge_index: 1, polygon_index: 1 }],
+    &[Connectivity { edge_index: 1, polygon_index: 1, cost: cost_01 }],
     &[
-      Connectivity { edge_index: 3, polygon_index: 0 },
-      Connectivity { edge_index: 1, polygon_index: 2 },
-      Connectivity { edge_index: 2, polygon_index: 3 },
+      Connectivity { edge_index: 3, polygon_index: 0, cost: cost_01 },
+      Connectivity { edge_index: 1, polygon_index: 2, cost: cost_12 },
+      Connectivity { edge_index: 2, polygon_index: 3, cost: cost_13 },
     ],
-    &[Connectivity { edge_index: 3, polygon_index: 1 }],
-    &[Connectivity { edge_index: 0, polygon_index: 1 }],
+    &[Connectivity { edge_index: 3, polygon_index: 1, cost: cost_12 }],
+    &[Connectivity { edge_index: 0, polygon_index: 1, cost: cost_13 }],
   ];
   assert_eq!(valid_mesh.connectivity, expected_connectivity);
   assert_eq!(


### PR DESCRIPTION
Previously:
- Connectivity and boundary links had to have their cost recomputed during pathfinding (including repeatedly travelling across the same edge/link).
- To know whether an edge was connected or not, you had to iterate through the connectivity.

Now:
- Connectivity and boundary links compute their cost during nav mesh validation and island linking respectively. This means pathfinding should be much faster since we don't have to recompute those costs all the time.
- Connectivity is stored per-edge in the polygons. This makes it easy to lookup whether an edge is connected or not, though at the cost of potentially higher memory usage (this should be fairly small).