### PR TITLE
Add support for non-AI controlled characters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ let agent_1 = archipelago.add_agent({
     /* max_velocity= */ 1.0,
   );
   agent.current_target = Some(Vec3::new(11.0, 0.0, 1.1));
-  agent.target_reached_condition = TargetReachedCondition::Distance(0.01);
+  agent.target_reached_condition = TargetReachedCondition::Distance(Some(0.01));
   agent
 });
 let agent_2 = archipelago.add_agent({
@@ -98,7 +98,7 @@ let agent_2 = archipelago.add_agent({
     /* max_velocity= */ 1.0,
   );
   agent.current_target = Some(Vec3::new(1.0, 0.0, 1.0));
-  agent.target_reached_condition = TargetReachedCondition::Distance(0.01);
+  agent.target_reached_condition = TargetReachedCondition::Distance(Some(0.01));
   agent
 });
 

--- a/src/agent_test.rs
+++ b/src/agent_test.rs
@@ -38,9 +38,9 @@ fn has_reached_target_at_end_node() {
 
   let first_path_index = PathIndex::from_corridor_index(0, 0);
   for condition in [
-    TargetReachedCondition::Distance(2.0),
-    TargetReachedCondition::StraightPathDistance(2.0),
-    TargetReachedCondition::VisibleAtDistance(2.0),
+    TargetReachedCondition::Distance(Some(2.0)),
+    TargetReachedCondition::StraightPathDistance(Some(2.0)),
+    TargetReachedCondition::VisibleAtDistance(Some(2.0)),
   ] {
     agent.target_reached_condition = condition;
 
@@ -114,7 +114,8 @@ fn long_detour_reaches_target_in_different_ways() {
 
   {
     agent.position = transform.apply(Vec3::new(1.0, 0.0, 1.0));
-    agent.target_reached_condition = TargetReachedCondition::Distance(1.1);
+    agent.target_reached_condition =
+      TargetReachedCondition::Distance(Some(1.1));
 
     // Agent started within 1.1 units of the destination, so they are close
     // enough.
@@ -150,7 +151,7 @@ fn long_detour_reaches_target_in_different_ways() {
 
   {
     agent.target_reached_condition =
-      TargetReachedCondition::VisibleAtDistance(15.0);
+      TargetReachedCondition::VisibleAtDistance(Some(15.0));
 
     // The agent cannot see the target and its path is still too long.
     agent.position = transform.apply(Vec3::new(1.0, 0.0, 1.0));
@@ -217,7 +218,7 @@ fn long_detour_reaches_target_in_different_ways() {
 
   {
     agent.target_reached_condition =
-      TargetReachedCondition::StraightPathDistance(15.0);
+      TargetReachedCondition::StraightPathDistance(Some(15.0));
 
     // The agent's path is too long (21 units).
     agent.position = transform.apply(Vec3::new(1.0, 0.0, 1.0));

--- a/src/character.rs
+++ b/src/character.rs
@@ -1,0 +1,19 @@
+use glam::Vec3;
+use slotmap::new_key_type;
+
+new_key_type! {
+  /// The ID of a character.
+  pub struct CharacterId;
+}
+
+/// A non-agent character. While agents are "managed" by the archipelago,
+/// characters are only as obstacles to be avoided by agents.
+#[derive(Default, Debug)]
+pub struct Character {
+  /// The current position of the character.
+  pub position: Vec3,
+  /// The current velocity of the character.
+  pub velocity: Vec3,
+  /// The radius of the character.
+  pub radius: f32,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,6 +188,18 @@ impl Archipelago {
       }
     }
 
+    let mut character_id_to_nav_mesh_point = HashMap::new();
+    for (character_id, character) in self.characters.iter() {
+      let character_point = match self.nav_data.sample_point(
+        character.position,
+        self.agent_options.node_sample_distance,
+      ) {
+        None => continue,
+        Some(point_and_node) => point_and_node.0,
+      };
+      character_id_to_nav_mesh_point.insert(character_id, character_point);
+    }
+
     let mut agent_id_to_follow_path_indices = HashMap::new();
 
     for (agent_id, agent) in self.agents.iter_mut() {
@@ -312,6 +324,8 @@ impl Archipelago {
     apply_avoidance_to_agents(
       &mut self.agents,
       &agent_id_to_agent_node,
+      &self.characters,
+      &character_id_to_nav_mesh_point,
       &self.nav_data,
       &self.agent_options,
       delta_time,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 mod agent;
 mod astar;
 mod avoidance;
+mod character;
 mod geometry;
 mod island;
 mod nav_data;
@@ -22,6 +23,7 @@ pub use glam::Vec3;
 pub mod debug;
 
 pub use agent::{Agent, AgentId, AgentState, TargetReachedCondition};
+pub use character::{Character, CharacterId};
 pub use island::{Island, IslandId};
 pub use nav_mesh::{NavigationMesh, ValidNavigationMesh, ValidationError};
 pub use util::{BoundingBox, Transform};
@@ -32,6 +34,7 @@ pub struct Archipelago {
   pub agent_options: AgentOptions,
   nav_data: NavigationData,
   agents: HopSlotMap<AgentId, Agent>,
+  characters: HopSlotMap<CharacterId, Character>,
   pathing_results: Vec<PathingResult>,
 }
 
@@ -66,6 +69,7 @@ impl Archipelago {
       nav_data: NavigationData::new(),
       agent_options: AgentOptions::default(),
       agents: HopSlotMap::with_key(),
+      characters: HopSlotMap::with_key(),
       pathing_results: Vec::new(),
     }
   }
@@ -91,6 +95,34 @@ impl Archipelago {
 
   pub fn get_agent_ids(&self) -> impl ExactSizeIterator<Item = AgentId> + '_ {
     self.agents.keys()
+  }
+
+  pub fn add_character(&mut self, character: Character) -> CharacterId {
+    self.characters.insert(character)
+  }
+
+  pub fn remove_character(&mut self, character_id: CharacterId) {
+    self
+      .characters
+      .remove(character_id)
+      .expect("Character should be present in the archipelago");
+  }
+
+  pub fn get_character(&self, character_id: CharacterId) -> &Character {
+    self.characters.get(character_id).unwrap()
+  }
+
+  pub fn get_character_mut(
+    &mut self,
+    character_id: CharacterId,
+  ) -> &mut Character {
+    self.characters.get_mut(character_id).unwrap()
+  }
+
+  pub fn get_character_ids(
+    &self,
+  ) -> impl ExactSizeIterator<Item = CharacterId> + '_ {
+    self.characters.keys()
   }
 
   pub fn add_island(&mut self) -> IslandId {

--- a/src/lib_test.rs
+++ b/src/lib_test.rs
@@ -7,8 +7,8 @@ use crate::{
   does_agent_need_repath,
   nav_data::NodeRef,
   path::{IslandSegment, Path, PathIndex},
-  Agent, AgentId, AgentState, Archipelago, BoundingBox, IslandId,
-  NavigationMesh, RepathResult, Transform, ValidNavigationMesh,
+  Agent, AgentId, AgentState, Archipelago, BoundingBox, Character, CharacterId,
+  IslandId, NavigationMesh, RepathResult, Transform, ValidNavigationMesh,
 };
 
 #[test]
@@ -252,6 +252,64 @@ fn add_and_remove_agents() {
   archipelago.remove_agent(agent_1);
 
   assert_eq!(archipelago.get_agent_ids().collect::<Vec<_>>(), []);
+}
+
+#[test]
+fn add_and_remove_characters() {
+  let mut archipelago = Archipelago::new();
+
+  let character_1 =
+    archipelago.add_character(Character { radius: 1.0, ..Default::default() });
+
+  let character_2 =
+    archipelago.add_character(Character { radius: 2.0, ..Default::default() });
+
+  let character_3 =
+    archipelago.add_character(Character { radius: 3.0, ..Default::default() });
+
+  fn sorted(mut v: Vec<CharacterId>) -> Vec<CharacterId> {
+    v.sort();
+    v
+  }
+
+  assert_eq!(
+    sorted(archipelago.get_character_ids().collect::<Vec<_>>()),
+    sorted(vec![character_1, character_2, character_3]),
+  );
+  assert_eq!(
+    [
+      archipelago.get_character(character_1).radius,
+      archipelago.get_character(character_2).radius,
+      archipelago.get_character(character_3).radius,
+    ],
+    [1.0, 2.0, 3.0],
+  );
+
+  archipelago.remove_character(character_2);
+
+  assert_eq!(
+    sorted(archipelago.get_character_ids().collect::<Vec<_>>()),
+    sorted(vec![character_1, character_3]),
+  );
+  assert_eq!(
+    [
+      archipelago.get_character(character_1).radius,
+      archipelago.get_character(character_3).radius,
+    ],
+    [1.0, 3.0],
+  );
+
+  archipelago.remove_character(character_3);
+
+  assert_eq!(
+    sorted(archipelago.get_character_ids().collect::<Vec<_>>()),
+    sorted(vec![character_1]),
+  );
+  assert_eq!([archipelago.get_character(character_1).radius], [1.0]);
+
+  archipelago.remove_character(character_1);
+
+  assert_eq!(archipelago.get_character_ids().collect::<Vec<_>>(), []);
 }
 
 #[test]


### PR DESCRIPTION
Previously, there was no good way to represent non-AI characters. You maybe could have made an agent that never had a target, but this was hacky at best. Now we have proper support for non-AI characters. Users just need to add characters using `Archipelago::add_character` and then keep their position/velocity updated. AI characters will then avoid these characters.

Fixes #9.