### PR TITLE
Fix a crash when creating nav meshes with no polygons or vertices.

### DIFF
--- a/crates/landmass/Cargo.toml
+++ b/crates/landmass/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["game-development"]
 keywords = ["navigation", "system", "pathfinding", "avoidance"]
 
 [dependencies]
-dodgy_2d = "0.5.0"
+dodgy_2d = "0.5.1"
 glam = "0.25.0"
 kdtree = "0.7.0"
 ord_subset = "3.1.1"

--- a/crates/landmass/src/nav_data.rs
+++ b/crates/landmass/src/nav_data.rs
@@ -229,6 +229,7 @@ impl NavigationData {
         value
           .nav_data
           .as_ref()
+          .filter(|nav_data| !nav_data.nav_mesh.mesh_bounds.is_empty())
           .map(|nav_data| (nav_data.transformed_bounds, Some(key)))
       })
       .collect::<Vec<_>>();

--- a/crates/landmass/src/nav_data_test.rs
+++ b/crates/landmass/src/nav_data_test.rs
@@ -893,3 +893,40 @@ fn stale_modified_nodes_are_removed() {
 
   assert_eq!(nav_data.modified_nodes.len(), 0);
 }
+
+#[test]
+fn empty_navigation_mesh_is_safe() {
+  let full_nav_mesh = Arc::new(
+    NavigationMesh {
+      vertices: vec![
+        Vec3::new(0.0, 0.0, 0.0),
+        Vec3::new(1.0, 0.0, 0.0),
+        Vec3::new(1.0, 0.0, 1.0),
+        Vec3::new(0.0, 0.0, 1.0),
+      ],
+      polygons: vec![vec![0, 1, 2, 3]],
+      mesh_bounds: None,
+    }
+    .validate()
+    .expect("A square nav mesh is valid."),
+  );
+
+  let mut full_island = Island::new();
+  full_island.set_nav_mesh(Transform::default(), full_nav_mesh);
+
+  let empty_nav_mesh = Arc::new(
+    NavigationMesh { vertices: vec![], polygons: vec![], mesh_bounds: None }
+      .validate()
+      .expect("An empty nav mesh is valid."),
+  );
+
+  let mut empty_island = Island::new();
+  empty_island.set_nav_mesh(Transform::default(), empty_nav_mesh);
+
+  let mut nav_data = NavigationData::new();
+  nav_data.islands.insert(full_island);
+  nav_data.islands.insert(empty_island);
+
+  // Nothing should panic here.
+  nav_data.update(/* edge_link_distance= */ 1e-6);
+}

--- a/crates/landmass/src/util.rs
+++ b/crates/landmass/src/util.rs
@@ -25,6 +25,11 @@ impl BoundingBox {
     Self::Box { min, max }
   }
 
+  /// Returns whether the box is empty or not.
+  pub fn is_empty(&self) -> bool {
+    matches!(self, Self::Empty)
+  }
+
   /// Returns the bounds of the box, assuming it is non-empty.
   pub fn as_box(&self) -> (Vec3, Vec3) {
     match self {


### PR DESCRIPTION
Previously no polygons or vertices would just crash. Now these nav meshes are ignored. We could call empty nav meshes invalid (and check for this in `NavigationMesh::validate`). I am still on the fence about that, so for now we are just gonna fix it and move on.

Also bumped the dodgy version.