### PR TITLE
Bump the version of bevy_landmass and landmass.

### DIFF
--- a/crates/bevy_landmass/Cargo.toml
+++ b/crates/bevy_landmass/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_landmass"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 
 description = "A plugin for Bevy to handle navigation of AI characters."
@@ -23,7 +23,7 @@ bevy = { version = "0.13.0", default-features = false, features = [
   "bevy_asset",
   "bevy_gizmos",
 ] }
-landmass = { path = "../landmass", version = "0.4.0" }
+landmass = { path = "../landmass", version = "0.5.0" }
 
 [dev-dependencies]
 bevy = "0.13.0"

--- a/crates/landmass/Cargo.toml
+++ b/crates/landmass/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "landmass"
-version = "0.4.0"
+version = "0.5.0"
 
 description = "A navigation system for video game characters to walk around levels."
 


### PR DESCRIPTION
I am not publishing these crates yet, I want to make sure I can upgrade to Bevy 0.14 first.