### PR TITLE
Switch the visibility of all internal types to `pub(crate)`.

### DIFF
--- a/crates/landmass/src/astar.rs
+++ b/crates/landmass/src/astar.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 /// A generic A* problem.
-pub trait AStarProblem {
+pub(crate) trait AStarProblem {
   /// The action that allows moving between states.
   type ActionType: Clone;
   /// The state that agents try to optimize.
@@ -106,24 +106,24 @@ fn recover_path_from_node<ProblemType: AStarProblem>(
 
 /// Stats about the pathfinding process.
 #[derive(Debug)]
-pub struct PathStats {
+pub(crate) struct PathStats {
   /// The number of nodes that were explored. This can exceed the number of
   /// states if there are faster paths than the heuristic "predicts".
-  pub explored_nodes: u32,
+  pub(crate) explored_nodes: u32,
 }
 
 /// The result of pathfinding.
 #[derive(Debug)]
-pub struct PathResult<ActionType> {
+pub(crate) struct PathResult<ActionType> {
   /// Stats about the pathfinding process.
-  pub stats: PathStats,
+  pub(crate) stats: PathStats,
   /// The path if one was found.
-  pub path: Option<Vec<ActionType>>,
+  pub(crate) path: Option<Vec<ActionType>>,
 }
 
 /// Finds a path in `problem` to get from the initial state to a goal state.
 /// Returns an `Err` if no path could be found.
-pub fn find_path<ProblemType: AStarProblem>(
+pub(crate) fn find_path<ProblemType: AStarProblem>(
   problem: &ProblemType,
 ) -> PathResult<ProblemType::ActionType> {
   let mut stats = PathStats { explored_nodes: 0 };

--- a/crates/landmass/src/geometry.rs
+++ b/crates/landmass/src/geometry.rs
@@ -1,6 +1,6 @@
 use glam::Vec3;
 
-pub fn edge_intersection(
+pub(crate) fn edge_intersection(
   edge_1: (Vec3, Vec3),
   edge_2: (Vec3, Vec3),
   intersection_distance_squared: f32,

--- a/crates/landmass/src/island.rs
+++ b/crates/landmass/src/island.rs
@@ -3,7 +3,8 @@ use std::sync::Arc;
 use slotmap::new_key_type;
 
 use crate::{
-  util::Transform, BoundingBox, CoordinateSystem, ValidNavigationMesh,
+  util::{BoundingBox, Transform},
+  CoordinateSystem, ValidNavigationMesh,
 };
 
 new_key_type! {
@@ -24,12 +25,12 @@ pub struct Island<CS: CoordinateSystem> {
 /// The navigation data of an island.
 pub(crate) struct IslandNavigationData<CS: CoordinateSystem> {
   /// The transform from the Island's frame to the Archipelago's frame.
-  pub transform: Transform<CS>,
+  pub(crate) transform: Transform<CS>,
   /// The navigation mesh for the island.
-  pub nav_mesh: Arc<ValidNavigationMesh<CS>>,
+  pub(crate) nav_mesh: Arc<ValidNavigationMesh<CS>>,
 
   // The bounds of `nav_mesh` after being transformed by `transform`.
-  pub transformed_bounds: BoundingBox,
+  pub(crate) transformed_bounds: BoundingBox,
 }
 
 impl<CS: CoordinateSystem> Island<CS> {

--- a/crates/landmass/src/lib.rs
+++ b/crates/landmass/src/lib.rs
@@ -29,7 +29,7 @@ pub use coords::{CoordinateSystem, XYZ};
 pub use island::{Island, IslandId};
 pub use nav_data::IslandMut;
 pub use nav_mesh::{NavigationMesh, ValidNavigationMesh, ValidationError};
-pub use util::{BoundingBox, Transform};
+pub use util::Transform;
 
 use crate::avoidance::apply_avoidance_to_agents;
 

--- a/crates/landmass/src/lib_test.rs
+++ b/crates/landmass/src/lib_test.rs
@@ -8,8 +8,9 @@ use crate::{
   does_agent_need_repath,
   nav_data::NodeRef,
   path::{IslandSegment, Path, PathIndex},
-  Agent, AgentId, AgentState, Archipelago, BoundingBox, Character, CharacterId,
-  IslandId, NavigationMesh, RepathResult, Transform, ValidNavigationMesh,
+  util::BoundingBox,
+  Agent, AgentId, AgentState, Archipelago, Character, CharacterId, IslandId,
+  NavigationMesh, RepathResult, Transform, ValidNavigationMesh,
 };
 
 #[test]

--- a/crates/landmass/src/nav_mesh.rs
+++ b/crates/landmass/src/nav_mesh.rs
@@ -4,7 +4,7 @@ use disjoint::DisjointSet;
 use glam::{swizzles::Vec3Swizzles, Vec3};
 use thiserror::Error;
 
-use crate::{coords::CoordinateSystem, BoundingBox};
+use crate::{coords::CoordinateSystem, util::BoundingBox};
 
 /// A navigation mesh.
 pub struct NavigationMesh<CS: CoordinateSystem> {
@@ -299,30 +299,30 @@ pub(crate) struct ValidPolygon {
 }
 
 #[derive(PartialEq, Debug, Clone)]
-pub struct Connectivity {
+pub(crate) struct Connectivity {
   /// The index of the polygon that this edge leads to.
-  pub polygon_index: usize,
+  pub(crate) polygon_index: usize,
   /// The cost of travelling across this connection.
-  pub cost: f32,
+  pub(crate) cost: f32,
 }
 
 /// A reference to an edge on a navigation mesh.
 #[derive(PartialEq, Eq, Debug, Clone, Hash, Default)]
-pub struct MeshEdgeRef {
+pub(crate) struct MeshEdgeRef {
   /// The index of the polygon that this edge belongs to.
-  pub polygon_index: usize,
+  pub(crate) polygon_index: usize,
   /// The index of the edge within the polygon.
-  pub edge_index: usize,
+  pub(crate) edge_index: usize,
 }
 
 impl<CS: CoordinateSystem> ValidNavigationMesh<CS> {
   /// Returns the bounds of the navigation mesh.
-  pub fn get_bounds(&self) -> BoundingBox {
+  pub(crate) fn get_bounds(&self) -> BoundingBox {
     self.mesh_bounds
   }
 
   // Gets the points that make up the specified edge.
-  pub fn get_edge_points(&self, edge_ref: MeshEdgeRef) -> (Vec3, Vec3) {
+  pub(crate) fn get_edge_points(&self, edge_ref: MeshEdgeRef) -> (Vec3, Vec3) {
     let polygon = &self.polygons[edge_ref.polygon_index];
     let left_vertex_index = polygon.vertices[edge_ref.edge_index];
 

--- a/crates/landmass/src/path.rs
+++ b/crates/landmass/src/path.rs
@@ -23,23 +23,23 @@ pub struct Path {
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub(crate) struct IslandSegment {
   /// The island that the nodes belong to.
-  pub island_id: IslandId,
+  pub(crate) island_id: IslandId,
   /// The nodes belonging to the path as their polygon index. Must have at
   /// least one element.
-  pub corridor: Vec<usize>,
+  pub(crate) corridor: Vec<usize>,
   /// The "portals" used between each node in [`IslandSegment::corridor`]. The
   /// portals are the edges that the agent must cross along its path. Must
   /// have exactly one less element than [`IslandSegment::corridor`].
-  pub portal_edge_index: Vec<usize>,
+  pub(crate) portal_edge_index: Vec<usize>,
 }
 
 /// Part of a path taking a BoundaryLink.
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub(crate) struct BoundaryLinkSegment {
   /// The node that the boundary link starts from.
-  pub starting_node: NodeRef,
+  pub(crate) starting_node: NodeRef,
   /// The link to be used.
-  pub boundary_link: BoundaryLinkId,
+  pub(crate) boundary_link: BoundaryLinkId,
 }
 
 impl IslandSegment {
@@ -85,15 +85,18 @@ impl BoundaryLinkSegment {
 /// An index in a path.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub(crate) struct PathIndex {
-  /// The
+  /// The index of the segment this belongs to.
   segment_index: usize,
+  /// The index of the portal in the corridor. The last index in a corrider
+  /// either corresponds to the boundary link to the next segment or the target
+  /// node.
   portal_index: usize,
 }
 
 impl PathIndex {
   /// Creates a `PathIndex` starting at the `island_segment_index` at the
   /// `corridor_index`.
-  pub fn from_corridor_index(
+  pub(crate) fn from_corridor_index(
     island_segment_index: usize,
     corridor_index: usize,
   ) -> Self {

--- a/crates/landmass/src/util.rs
+++ b/crates/landmass/src/util.rs
@@ -33,6 +33,7 @@ impl BoundingBox {
   }
 
   /// Returns the bounds of the box, assuming it is non-empty.
+  #[allow(unused)] // Used by tests.
   pub(crate) fn as_box(&self) -> (Vec3, Vec3) {
     match self {
       Self::Empty => panic!("BoundingBox is not a box."),
@@ -118,6 +119,7 @@ impl BoundingBox {
   }
 
   /// Determines if `other` is fully contained by `self`.
+  #[allow(unused)] // Used by tests.
   pub(crate) fn contains_bounds(&self, other: &Self) -> bool {
     let (other_min, other_max) = match other {
       Self::Empty => return false,

--- a/crates/landmass/src/util_test.rs
+++ b/crates/landmass/src/util_test.rs
@@ -2,7 +2,7 @@ use std::f32::consts::PI;
 
 use glam::Vec3;
 
-use crate::{BoundingBox, Transform, XYZ};
+use crate::{util::BoundingBox, Transform, XYZ};
 
 use super::BoundingBoxHierarchy;
 


### PR DESCRIPTION
This prevents types and functions from accidentally being made public, and makes it more clear the intent of different types.

I was also able to track down some types that no longer need to be public at all!