### PR TITLE
Add `sample_point` to `Archipelago`.

### DIFF
--- a/crates/landmass/src/coords.rs
+++ b/crates/landmass/src/coords.rs
@@ -41,6 +41,6 @@ impl CoordinateSystem for XY {
   }
 
   fn from_landmass(v: &Vec3) -> Self::Coordinate {
-    Vec2::new(v.x, v.z)
+    Vec2::new(v.x, v.y)
   }
 }

--- a/crates/landmass/src/lib.rs
+++ b/crates/landmass/src/lib.rs
@@ -11,6 +11,7 @@ mod nav_data;
 mod nav_mesh;
 mod path;
 mod pathfinding;
+mod query;
 mod util;
 
 use path::PathIndex;
@@ -29,6 +30,7 @@ pub use coords::{CoordinateSystem, XYZ};
 pub use island::{Island, IslandId};
 pub use nav_data::IslandMut;
 pub use nav_mesh::{NavigationMesh, ValidNavigationMesh, ValidationError};
+pub use query::SamplePointError;
 pub use util::Transform;
 
 use crate::avoidance::apply_avoidance_to_agents;
@@ -157,6 +159,16 @@ impl<CS: CoordinateSystem> Archipelago<CS> {
   /// Gets the pathing results from the last [`Self::update`] call.
   pub fn get_pathing_results(&self) -> &[PathingResult] {
     &self.pathing_results
+  }
+
+  /// Finds the nearest point on the navigation meshes to (and within
+  /// `distance_to_node` of) `point`.
+  pub fn sample_point(
+    &self,
+    point: CS::Coordinate,
+    distance_to_node: f32,
+  ) -> Result<CS::Coordinate, SamplePointError> {
+    query::sample_point(self, point, distance_to_node)
   }
 
   pub fn update(&mut self, delta_time: f32) {

--- a/crates/landmass/src/query.rs
+++ b/crates/landmass/src/query.rs
@@ -1,0 +1,36 @@
+use thiserror::Error;
+
+use crate::{Archipelago, CoordinateSystem};
+
+/// An error while sampling a point.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Error)]
+pub enum SamplePointError {
+  #[error("The sample point is too far from any island.")]
+  OutOfRange,
+  #[error("The navigation data of the archipelago has been mutated since the last update.")]
+  NavDataDirty,
+}
+
+/// Finds the nearest point on the navigation meshes to (and within
+/// `distance_to_node` of) `point`.
+pub(crate) fn sample_point<CS: CoordinateSystem>(
+  archipelago: &Archipelago<CS>,
+  point: CS::Coordinate,
+  distance_to_node: f32,
+) -> Result<CS::Coordinate, SamplePointError> {
+  if archipelago.nav_data.dirty {
+    return Err(SamplePointError::NavDataDirty);
+  }
+  let Some((point, _)) = archipelago
+    .nav_data
+    .sample_point(CS::to_landmass(&point), distance_to_node)
+  else {
+    return Err(SamplePointError::OutOfRange);
+  };
+
+  Ok(CS::from_landmass(&point))
+}
+
+#[cfg(test)]
+#[path = "query_test.rs"]
+mod test;

--- a/crates/landmass/src/query_test.rs
+++ b/crates/landmass/src/query_test.rs
@@ -1,0 +1,119 @@
+use std::sync::Arc;
+
+use glam::Vec2;
+
+use crate::{
+  coords::XY, Archipelago, NavigationMesh, SamplePointError, Transform,
+};
+
+use super::sample_point;
+
+#[test]
+fn error_on_dirty_nav_mesh() {
+  let mut archipelago = Archipelago::<XY>::new();
+
+  let nav_mesh = Arc::new(
+    NavigationMesh {
+      vertices: vec![
+        Vec2::new(0.0, 0.0),
+        Vec2::new(1.0, 0.0),
+        Vec2::new(1.0, 1.0),
+        Vec2::new(0.0, 1.0),
+      ],
+      polygons: vec![vec![0, 1, 2, 3]],
+    }
+    .validate()
+    .expect("nav mesh is valid"),
+  );
+
+  archipelago.add_island().set_nav_mesh(Transform::default(), nav_mesh);
+  assert_eq!(
+    sample_point(
+      &archipelago,
+      /* point= */ Vec2::new(0.5, 0.5),
+      /* distance_to_node= */ 1.0
+    ),
+    Err(SamplePointError::NavDataDirty)
+  );
+}
+
+#[test]
+fn error_on_out_of_range() {
+  let mut archipelago = Archipelago::<XY>::new();
+
+  let nav_mesh = Arc::new(
+    NavigationMesh {
+      vertices: vec![
+        Vec2::new(0.0, 0.0),
+        Vec2::new(1.0, 0.0),
+        Vec2::new(1.0, 1.0),
+        Vec2::new(0.0, 1.0),
+      ],
+      polygons: vec![vec![0, 1, 2, 3]],
+    }
+    .validate()
+    .expect("nav mesh is valid"),
+  );
+
+  archipelago.add_island().set_nav_mesh(Transform::default(), nav_mesh);
+  archipelago.update(1.0);
+
+  assert_eq!(
+    sample_point(
+      &archipelago,
+      /* point= */ Vec2::new(-0.5, 0.5),
+      /* distance_to_node= */ 0.1
+    ),
+    Err(SamplePointError::OutOfRange)
+  );
+}
+
+#[test]
+fn samples_point_on_nav_mesh_or_near_nav_mesh() {
+  let mut archipelago = Archipelago::<XY>::new();
+
+  let nav_mesh = Arc::new(
+    NavigationMesh {
+      vertices: vec![
+        Vec2::new(0.0, 0.0),
+        Vec2::new(1.0, 0.0),
+        Vec2::new(1.0, 1.0),
+        Vec2::new(0.0, 1.0),
+      ],
+      polygons: vec![vec![0, 1, 2, 3]],
+    }
+    .validate()
+    .expect("nav mesh is valid"),
+  );
+
+  let offset = Vec2::new(10.0, 10.0);
+  archipelago
+    .add_island()
+    .set_nav_mesh(Transform { translation: offset, rotation: 0.0 }, nav_mesh);
+  archipelago.update(1.0);
+
+  assert_eq!(
+    sample_point(
+      &archipelago,
+      /* point= */ offset + Vec2::new(-0.5, 0.5),
+      /* distance_to_node= */ 0.6
+    ),
+    Ok(offset + Vec2::new(0.0, 0.5))
+  );
+  assert_eq!(
+    sample_point(
+      &archipelago,
+      /* point= */ offset + Vec2::new(0.5, 0.5),
+      /* distance_to_node= */ 0.6
+    ),
+    Ok(offset + Vec2::new(0.5, 0.5))
+  );
+  assert_eq!(
+    sample_point(
+      &archipelago,
+      /* point= */ offset + Vec2::new(1.2, 1.2),
+      /* distance_to_node= */ 0.6
+    ),
+    Ok(offset + Vec2::new(1.0, 1.0))
+  );
+}


### PR DESCRIPTION
Now users can find points on the archipelago for their own uses!

For a concrete example of this: I have a game where I allow players to place objects, and these objects have a handful of "target points" around each object. I want my AI characters to randomly select one of these target points for an object and go there to interact with the object. However if the player places objects really close together, those points may be off the nav mesh. So I want to filter the target points based on whether they are on the nav mesh or not, hence this function.