### PR TITLE
Add support for "node types" with differing costs.

### DIFF
--- a/crates/bevy_landmass/README.md
+++ b/crates/bevy_landmass/README.md
@@ -77,6 +77,7 @@ fn set_up_scene(
         vec![3, 2, 4, 5],
         vec![5, 4, 6, 7],
       ],
+      polygon_type_indices: vec![0, 0, 0],
     }.validate().expect("is valid"));
   nav_meshes.insert(&nav_mesh_handle, NavMesh2d{ nav_mesh });
 

--- a/crates/bevy_landmass/README.md
+++ b/crates/bevy_landmass/README.md
@@ -79,7 +79,10 @@ fn set_up_scene(
       ],
       polygon_type_indices: vec![0, 0, 0],
     }.validate().expect("is valid"));
-  nav_meshes.insert(&nav_mesh_handle, NavMesh2d{ nav_mesh });
+  nav_meshes.insert(&nav_mesh_handle, NavMesh2d{
+    nav_mesh,
+    type_index_to_node_type: Default::default(),
+  });
 
   commands.spawn((
     TransformBundle {

--- a/crates/bevy_landmass/example/main.rs
+++ b/crates/bevy_landmass/example/main.rs
@@ -49,7 +49,10 @@ fn convert_mesh(
     let valid_nav_mesh = nav_mesh.validate().unwrap();
     nav_meshes.insert(
       &converter.nav_mesh,
-      NavMesh2d { nav_mesh: Arc::new(valid_nav_mesh) },
+      NavMesh2d {
+        nav_mesh: Arc::new(valid_nav_mesh),
+        type_index_to_node_type: Default::default(),
+      },
     );
     commands.entity(entity).remove::<ConvertMesh>();
   }

--- a/crates/bevy_landmass/src/lib.rs
+++ b/crates/bevy_landmass/src/lib.rs
@@ -22,6 +22,9 @@ mod landmass_structs;
 
 pub use landmass::AgentOptions;
 pub use landmass::NavigationMesh;
+pub use landmass::NewNodeTypeError;
+pub use landmass::NodeType;
+pub use landmass::SetNodeTypeCostError;
 pub use landmass::ValidNavigationMesh;
 pub use landmass::ValidationError;
 
@@ -238,6 +241,41 @@ impl<CS: CoordinateSystem> Archipelago<CS> {
   /// Gets a mutable borrow to the agent options.
   pub fn get_agent_options_mut(&mut self) -> &mut AgentOptions {
     &mut self.archipelago.agent_options
+  }
+
+  /// Creates a new node type with the specified `cost`. The cost is a
+  /// multiplier on the distance travelled along this node (essentially the cost
+  /// per meter). Agents will prefer to travel along low-cost terrain. The
+  /// returned node type is distinct from all other node types (for this
+  /// archipelago).
+  pub fn add_node_type(
+    &mut self,
+    cost: f32,
+  ) -> Result<NodeType, NewNodeTypeError> {
+    self.archipelago.add_node_type(cost)
+  }
+
+  /// Sets the cost of `node_type` to `cost`. See
+  /// [`Archipelago::add_node_type`] for the meaning of cost.
+  pub fn set_node_type_cost(
+    &mut self,
+    node_type: NodeType,
+    cost: f32,
+  ) -> Result<(), SetNodeTypeCostError> {
+    self.archipelago.set_node_type_cost(node_type, cost)
+  }
+
+  /// Gets the cost of `node_type`. Returns [`None`] if `node_type` is not in
+  /// this archipelago.
+  pub fn get_node_type_cost(&self, node_type: NodeType) -> Option<f32> {
+    self.archipelago.get_node_type_cost(node_type)
+  }
+
+  /// Removes the node type from the archipelago. Returns false if this
+  /// archipelago does not contain `node_type` or any islands still use this
+  /// node type (so the node type cannot be removed). Otherwise, returns true.
+  pub fn remove_node_type(&mut self, node_type: NodeType) -> bool {
+    self.archipelago.remove_node_type(node_type)
   }
 
   /// Gets an agent.

--- a/crates/bevy_landmass/src/lib.rs
+++ b/crates/bevy_landmass/src/lib.rs
@@ -437,8 +437,11 @@ fn sync_island_nav_mesh<CS: CoordinateSystem>(
     };
 
     if set_nav_mesh {
-      landmass_island
-        .set_nav_mesh(island_transform, Arc::clone(&island_nav_mesh.nav_mesh));
+      landmass_island.set_nav_mesh(
+        island_transform,
+        Arc::clone(&island_nav_mesh.nav_mesh),
+        HashMap::new(), // TODO: Make this not just an empty hashmap.
+      );
     }
   }
 }

--- a/crates/bevy_landmass/src/lib_test.rs
+++ b/crates/bevy_landmass/src/lib_test.rs
@@ -1,11 +1,14 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use bevy::prelude::*;
+use landmass::NavigationMesh;
 
 use crate::{
-  Agent, Agent3dBundle, AgentDesiredVelocity3d, AgentState, AgentTarget3d,
-  Archipelago3d, ArchipelagoRef3d, Character, Character3dBundle, Island,
-  Island3dBundle, Landmass3dPlugin, NavMesh3d, NavigationMesh3d, Velocity3d,
+  Agent, Agent2dBundle, Agent3dBundle, AgentDesiredVelocity2d,
+  AgentDesiredVelocity3d, AgentState, AgentTarget2d, AgentTarget3d,
+  Archipelago2d, Archipelago3d, ArchipelagoRef2d, ArchipelagoRef3d, Character,
+  Character3dBundle, Island, Island2dBundle, Island3dBundle, Landmass2dPlugin,
+  Landmass3dPlugin, NavMesh2d, NavMesh3d, NavigationMesh3d, Velocity3d,
 };
 
 #[test]
@@ -57,10 +60,10 @@ fn computes_path_for_agent_and_updates_desired_velocity() {
     })
     .insert(nav_mesh_handle.clone());
 
-  app
-    .world_mut()
-    .resource_mut::<Assets<NavMesh3d>>()
-    .insert(&nav_mesh_handle, NavMesh3d { nav_mesh });
+  app.world_mut().resource_mut::<Assets<NavMesh3d>>().insert(
+    &nav_mesh_handle,
+    NavMesh3d { nav_mesh, type_index_to_node_type: Default::default() },
+  );
 
   let agent_id = app
     .world_mut()
@@ -560,4 +563,121 @@ fn changing_character_fields_changes_landmass_character() {
   assert_eq!(agent_ref.position, Vec3::new(7.0, 8.0, 9.0));
   assert_eq!(agent_ref.velocity, Vec3::new(10.0, 11.0, 12.0));
   assert_eq!(agent_ref.radius, 2.0);
+}
+
+#[test]
+fn node_type_costs_are_used() {
+  let mut app = App::new();
+
+  app
+    .add_plugins(MinimalPlugins)
+    .add_plugins(TransformPlugin)
+    .add_plugins(AssetPlugin::default())
+    .add_plugins(Landmass2dPlugin::default());
+
+  let mut archipelago = Archipelago2d::new();
+  let slow_node_type = archipelago.add_node_type(10.0).unwrap();
+
+  let archipelago_id = app.world_mut().spawn(archipelago).id();
+
+  let nav_mesh = Arc::new(
+    NavigationMesh {
+      vertices: vec![
+        Vec2::new(0.0, 0.0),
+        Vec2::new(1.0, 0.0),
+        Vec2::new(1.0, 1.0),
+        Vec2::new(0.0, 1.0),
+        //
+        Vec2::new(2.0, 0.0),
+        Vec2::new(2.0, 1.0),
+        //
+        Vec2::new(3.0, 0.0),
+        Vec2::new(3.0, 1.0),
+        //
+        Vec2::new(2.0, 11.0),
+        Vec2::new(3.0, 11.0),
+        //
+        Vec2::new(2.0, 12.0),
+        Vec2::new(3.0, 12.0),
+        //
+        Vec2::new(1.0, 12.0),
+        Vec2::new(1.0, 11.0),
+        //
+        Vec2::new(0.0, 12.0),
+        Vec2::new(0.0, 11.0),
+      ],
+      polygons: vec![
+        vec![0, 1, 2, 3],
+        vec![2, 1, 4, 5],
+        vec![5, 4, 6, 7],
+        //
+        vec![5, 7, 9, 8],
+        vec![8, 9, 11, 10],
+        //
+        vec![8, 10, 12, 13],
+        vec![13, 12, 14, 15],
+        //
+        vec![3, 2, 13, 15],
+      ],
+      polygon_type_indices: vec![0, 0, 0, 0, 0, 0, 0, 1],
+    }
+    .validate()
+    .expect("nav mesh is valid"),
+  );
+
+  let nav_mesh_handle = app
+    .world()
+    .resource::<Assets<NavMesh2d>>()
+    .get_handle_provider()
+    .reserve_handle()
+    .typed::<NavMesh2d>();
+
+  app.world_mut().spawn(TransformBundle::default()).insert(Island2dBundle {
+    island: Island,
+    archipelago_ref: ArchipelagoRef2d::new(archipelago_id),
+    nav_mesh: nav_mesh_handle.clone(),
+  });
+
+  app.world_mut().resource_mut::<Assets<NavMesh2d>>().insert(
+    &nav_mesh_handle,
+    NavMesh2d {
+      nav_mesh,
+      type_index_to_node_type: HashMap::from([(1, slow_node_type)]),
+    },
+  );
+
+  let agent_id = app
+    .world_mut()
+    .spawn(TransformBundle {
+      local: Transform::from_translation(Vec3::new(0.5, 0.5, 1.0)),
+      ..Default::default()
+    })
+    .insert(Agent2dBundle {
+      agent: Agent { radius: 0.5, max_velocity: 1.0 },
+      archipelago_ref: ArchipelagoRef2d::new(archipelago_id),
+      target: AgentTarget2d::Point(Vec2::new(0.5, 11.5)),
+      velocity: Default::default(),
+      state: Default::default(),
+      desired_velocity: Default::default(),
+    })
+    .id();
+
+  // The first update propagates the global transform, and sets the start of
+  // the delta time (in this update, delta time is 0).
+  app.update();
+  // The second update allows landmass to update properly.
+  app.update();
+
+  assert_eq!(
+    *app.world().get::<AgentState>(agent_id).expect("current state was added"),
+    AgentState::Moving,
+  );
+  assert_eq!(
+    app
+      .world()
+      .get::<AgentDesiredVelocity2d>(agent_id)
+      .expect("desired velocity was added")
+      .0,
+    Vec2::new(1.5, 0.5).normalize(),
+  );
 }

--- a/crates/bevy_landmass/src/lib_test.rs
+++ b/crates/bevy_landmass/src/lib_test.rs
@@ -31,6 +31,7 @@ fn computes_path_for_agent_and_updates_desired_velocity() {
         Vec3::new(1.0, 0.0, 2.0),
       ],
       polygons: vec![vec![5, 4, 1, 0], vec![4, 3, 2, 1]],
+      polygon_type_indices: vec![0, 0],
     }
     .validate()
     .expect("is valid"),

--- a/crates/bevy_landmass/src/lib_test.rs
+++ b/crates/bevy_landmass/src/lib_test.rs
@@ -5,10 +5,11 @@ use landmass::NavigationMesh;
 
 use crate::{
   Agent, Agent2dBundle, Agent3dBundle, AgentDesiredVelocity2d,
-  AgentDesiredVelocity3d, AgentState, AgentTarget2d, AgentTarget3d,
-  Archipelago2d, Archipelago3d, ArchipelagoRef2d, ArchipelagoRef3d, Character,
-  Character3dBundle, Island, Island2dBundle, Island3dBundle, Landmass2dPlugin,
-  Landmass3dPlugin, NavMesh2d, NavMesh3d, NavigationMesh3d, Velocity3d,
+  AgentDesiredVelocity3d, AgentNodeTypeCostOverrides, AgentState,
+  AgentTarget2d, AgentTarget3d, Archipelago2d, Archipelago3d, ArchipelagoRef2d,
+  ArchipelagoRef3d, Character, Character3dBundle, Island, Island2dBundle,
+  Island3dBundle, Landmass2dPlugin, Landmass3dPlugin, NavMesh2d, NavMesh3d,
+  NavigationMesh3d, Velocity3d,
 };
 
 #[test]
@@ -659,6 +660,128 @@ fn node_type_costs_are_used() {
       velocity: Default::default(),
       state: Default::default(),
       desired_velocity: Default::default(),
+    })
+    .id();
+
+  // The first update propagates the global transform, and sets the start of
+  // the delta time (in this update, delta time is 0).
+  app.update();
+  // The second update allows landmass to update properly.
+  app.update();
+
+  assert_eq!(
+    *app.world().get::<AgentState>(agent_id).expect("current state was added"),
+    AgentState::Moving,
+  );
+  assert_eq!(
+    app
+      .world()
+      .get::<AgentDesiredVelocity2d>(agent_id)
+      .expect("desired velocity was added")
+      .0,
+    Vec2::new(1.5, 0.5).normalize(),
+  );
+}
+
+#[test]
+fn overridden_node_type_costs_are_used() {
+  let mut app = App::new();
+
+  app
+    .add_plugins(MinimalPlugins)
+    .add_plugins(TransformPlugin)
+    .add_plugins(AssetPlugin::default())
+    .add_plugins(Landmass2dPlugin::default());
+
+  let mut archipelago = Archipelago2d::new();
+  let slow_node_type = archipelago.add_node_type(1.0).unwrap();
+
+  let archipelago_id = app.world_mut().spawn(archipelago).id();
+
+  let nav_mesh = Arc::new(
+    NavigationMesh {
+      vertices: vec![
+        Vec2::new(0.0, 0.0),
+        Vec2::new(1.0, 0.0),
+        Vec2::new(1.0, 1.0),
+        Vec2::new(0.0, 1.0),
+        //
+        Vec2::new(2.0, 0.0),
+        Vec2::new(2.0, 1.0),
+        //
+        Vec2::new(3.0, 0.0),
+        Vec2::new(3.0, 1.0),
+        //
+        Vec2::new(2.0, 11.0),
+        Vec2::new(3.0, 11.0),
+        //
+        Vec2::new(2.0, 12.0),
+        Vec2::new(3.0, 12.0),
+        //
+        Vec2::new(1.0, 12.0),
+        Vec2::new(1.0, 11.0),
+        //
+        Vec2::new(0.0, 12.0),
+        Vec2::new(0.0, 11.0),
+      ],
+      polygons: vec![
+        vec![0, 1, 2, 3],
+        vec![2, 1, 4, 5],
+        vec![5, 4, 6, 7],
+        //
+        vec![5, 7, 9, 8],
+        vec![8, 9, 11, 10],
+        //
+        vec![8, 10, 12, 13],
+        vec![13, 12, 14, 15],
+        //
+        vec![3, 2, 13, 15],
+      ],
+      polygon_type_indices: vec![0, 0, 0, 0, 0, 0, 0, 1],
+    }
+    .validate()
+    .expect("nav mesh is valid"),
+  );
+
+  let nav_mesh_handle = app
+    .world()
+    .resource::<Assets<NavMesh2d>>()
+    .get_handle_provider()
+    .reserve_handle()
+    .typed::<NavMesh2d>();
+
+  app.world_mut().spawn(TransformBundle::default()).insert(Island2dBundle {
+    island: Island,
+    archipelago_ref: ArchipelagoRef2d::new(archipelago_id),
+    nav_mesh: nav_mesh_handle.clone(),
+  });
+
+  app.world_mut().resource_mut::<Assets<NavMesh2d>>().insert(
+    &nav_mesh_handle,
+    NavMesh2d {
+      nav_mesh,
+      type_index_to_node_type: HashMap::from([(1, slow_node_type)]),
+    },
+  );
+
+  let agent_id = app
+    .world_mut()
+    .spawn(TransformBundle {
+      local: Transform::from_translation(Vec3::new(0.5, 0.5, 1.0)),
+      ..Default::default()
+    })
+    .insert(Agent2dBundle {
+      agent: Agent { radius: 0.5, max_velocity: 1.0 },
+      archipelago_ref: ArchipelagoRef2d::new(archipelago_id),
+      target: AgentTarget2d::Point(Vec2::new(0.5, 11.5)),
+      velocity: Default::default(),
+      state: Default::default(),
+      desired_velocity: Default::default(),
+    })
+    .insert({
+      let mut overrides = AgentNodeTypeCostOverrides::default();
+      overrides.set_node_type_cost(slow_node_type, 10.0);
+      overrides
     })
     .id();
 

--- a/crates/bevy_landmass/src/nav_mesh.rs
+++ b/crates/bevy_landmass/src/nav_mesh.rs
@@ -71,7 +71,11 @@ pub fn bevy_mesh_to_landmass_nav_mesh<CS: CoordinateSystem>(
     _ => return Err(ConvertMeshError::WrongTypeForIndices),
   };
 
-  Ok(NavigationMesh { vertices, polygons })
+  Ok(NavigationMesh {
+    vertices,
+    polygon_type_indices: (0..polygons.len()).map(|_| 0).collect(),
+    polygons,
+  })
 }
 
 #[cfg(test)]

--- a/crates/landmass/README.md
+++ b/crates/landmass/README.md
@@ -53,7 +53,7 @@ be confusing.
 ```rust
 use glam::Vec3;
 use landmass::*;
-use std::sync::Arc;
+use std::{sync::Arc, collections::HashMap};
 
 let mut archipelago = Archipelago::<XYZ>::new();
 
@@ -77,6 +77,7 @@ let island_id = archipelago
   .set_nav_mesh(
     Transform { translation: Vec3::ZERO, rotation: 0.0 },
     valid_nav_mesh,
+    HashMap::new(),
   )
   .id();
 

--- a/crates/landmass/README.md
+++ b/crates/landmass/README.md
@@ -65,6 +65,7 @@ let nav_mesh = NavigationMesh {
     Vec3::new(0.0, 15.0, 0.0),
   ],
   polygons: vec![vec![0, 1, 2, 3]],
+  polygon_type_indices: vec![0],
 };
 
 let valid_nav_mesh = Arc::new(

--- a/crates/landmass/src/agent_test.rs
+++ b/crates/landmass/src/agent_test.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashSet, f32::consts::PI, sync::Arc};
+use std::{
+  collections::{HashMap, HashSet},
+  f32::consts::PI,
+  sync::Arc,
+};
 
 use glam::Vec3;
 use slotmap::HopSlotMap;
@@ -26,7 +30,7 @@ fn has_reached_target_at_end_node() {
   let mut archipelago = Archipelago::<XYZ>::new();
   let island_id = archipelago
     .add_island()
-    .set_nav_mesh(transform.clone(), Arc::new(nav_mesh))
+    .set_nav_mesh(transform.clone(), Arc::new(nav_mesh), HashMap::new())
     .id();
   let mut agent = Agent::create(
     /* position= */ transform.apply(Vec3::new(1.0, 0.0, 1.0)),
@@ -101,7 +105,7 @@ fn long_detour_reaches_target_in_different_ways() {
   let mut archipelago = Archipelago::<XYZ>::new();
   let island_id = archipelago
     .add_island()
-    .set_nav_mesh(transform.clone(), Arc::new(nav_mesh))
+    .set_nav_mesh(transform.clone(), Arc::new(nav_mesh), HashMap::new())
     .id();
 
   let mut agent = Agent::create(

--- a/crates/landmass/src/agent_test.rs
+++ b/crates/landmass/src/agent_test.rs
@@ -14,9 +14,13 @@ use crate::{
 
 #[test]
 fn has_reached_target_at_end_node() {
-  let nav_mesh = NavigationMesh { vertices: vec![], polygons: vec![] }
-    .validate()
-    .expect("nav mesh is valid");
+  let nav_mesh = NavigationMesh {
+    vertices: vec![],
+    polygons: vec![],
+    polygon_type_indices: vec![],
+  }
+  .validate()
+  .expect("nav mesh is valid");
   let transform =
     Transform { translation: Vec3::new(2.0, 3.0, 4.0), rotation: PI * 0.85 };
   let mut archipelago = Archipelago::<XYZ>::new();
@@ -87,6 +91,7 @@ fn long_detour_reaches_target_in_different_ways() {
       Vec3::new(2.0, 1.0, 0.0),
     ],
     polygons: vec![vec![0, 1, 2], vec![2, 1, 3, 4], vec![4, 3, 5]],
+    polygon_type_indices: vec![0, 0, 0],
   }
   .validate()
   .expect("nav mesh is valid");

--- a/crates/landmass/src/avoidance_test.rs
+++ b/crates/landmass/src/avoidance_test.rs
@@ -89,6 +89,7 @@ fn computes_obstacle_for_box() {
     .set_nav_mesh(
       Transform { translation: island_offset, rotation: 0.0 },
       Arc::new(nav_mesh),
+      HashMap::new(),
     )
     .id();
 
@@ -147,6 +148,7 @@ fn dead_end_makes_open_obstacle() {
     .set_nav_mesh(
       Transform { translation: Vec3::ZERO, rotation: 0.0 },
       Arc::new(nav_mesh),
+      HashMap::new(),
     )
     .id();
 
@@ -292,6 +294,7 @@ fn split_borders() {
     .set_nav_mesh(
       Transform { translation: Vec3::ZERO, rotation: 0.0 },
       Arc::new(nav_mesh),
+      HashMap::new(),
     )
     .id();
 
@@ -351,12 +354,14 @@ fn creates_obstacles_across_boundary_link() {
   nav_data.add_island().set_nav_mesh(
     Transform { translation: Vec3::ZERO, rotation: 0.0 },
     Arc::clone(&nav_mesh),
+    HashMap::new(),
   );
   let island_id_2 = nav_data
     .add_island()
     .set_nav_mesh(
       Transform { translation: Vec3::new(1.0, 0.0, 0.0), rotation: 0.0 },
       nav_mesh,
+      HashMap::new(),
     )
     .id();
 
@@ -413,6 +418,7 @@ fn applies_no_avoidance_for_far_agents() {
     .set_nav_mesh(
       Transform { translation: Vec3::ZERO, rotation: 0.0 },
       Arc::new(nav_mesh),
+      HashMap::new(),
     )
     .id();
 
@@ -510,6 +516,7 @@ fn applies_avoidance_for_two_agents() {
     .set_nav_mesh(
       Transform { translation: Vec3::ZERO, rotation: 0.0 },
       Arc::new(nav_mesh),
+      HashMap::new(),
     )
     .id();
 
@@ -605,6 +612,7 @@ fn agent_avoids_character() {
     .set_nav_mesh(
       Transform { translation: Vec3::ZERO, rotation: 0.0 },
       Arc::new(nav_mesh),
+      HashMap::new(),
     )
     .id();
 

--- a/crates/landmass/src/avoidance_test.rs
+++ b/crates/landmass/src/avoidance_test.rs
@@ -73,6 +73,7 @@ fn computes_obstacle_for_box() {
       Vec3::new(1.0, 2.0, 0.0),
     ],
     polygons: vec![vec![0, 1, 2, 3]],
+    polygon_type_indices: vec![0],
   }
   .validate()
   .expect("Validation succeeds");
@@ -135,6 +136,7 @@ fn dead_end_makes_open_obstacle() {
       vec![5, 7, 8, 9],
       vec![9, 8, 10, 11],
     ],
+    polygon_type_indices: vec![0, 0, 0, 0, 0],
   }
   .validate()
   .expect("Validation succeeds");
@@ -279,6 +281,7 @@ fn split_borders() {
       vec![24, 21, 20, 25],
       vec![23, 22, 21, 24],
     ],
+    polygon_type_indices: vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
   }
   .validate()
   .expect("Validation succeeds");
@@ -338,6 +341,7 @@ fn creates_obstacles_across_boundary_link() {
         Vec3::new(1.0, 2.0, 1.0),
       ],
       polygons: vec![vec![0, 1, 2, 3]],
+      polygon_type_indices: vec![0],
     }
     .validate()
     .expect("Validation succeeds"),
@@ -398,6 +402,7 @@ fn applies_no_avoidance_for_far_agents() {
       Vec3::new(-1.0, 3.0, 0.0),
     ],
     polygons: vec![vec![0, 1, 2, 3]],
+    polygon_type_indices: vec![0],
   }
   .validate()
   .expect("Validation succeeded.");
@@ -494,6 +499,7 @@ fn applies_avoidance_for_two_agents() {
       Vec3::new(-1.0, 3.0, 0.0),
     ],
     polygons: vec![vec![0, 1, 2, 3]],
+    polygon_type_indices: vec![0],
   }
   .validate()
   .expect("Validation succeeded.");
@@ -588,6 +594,7 @@ fn agent_avoids_character() {
       Vec3::new(-1.0, 3.0, 0.0),
     ],
     polygons: vec![vec![0, 1, 2, 3]],
+    polygon_type_indices: vec![0],
   }
   .validate()
   .expect("Validation succeeded.");

--- a/crates/landmass/src/debug_test.rs
+++ b/crates/landmass/src/debug_test.rs
@@ -1,4 +1,4 @@
-use std::{cmp::Ordering, sync::Arc};
+use std::{cmp::Ordering, collections::HashMap, sync::Arc};
 
 use glam::Vec3;
 
@@ -101,6 +101,7 @@ fn draws_island_meshes_and_agents() {
     .set_nav_mesh(
       Transform { translation: TRANSLATION, rotation: 0.0 },
       Arc::new(nav_mesh),
+      HashMap::new(),
     )
     .id();
 
@@ -433,13 +434,14 @@ fn draws_boundary_links() {
   let mut archipelago = Archipelago::<XYZ>::new();
   archipelago
     .add_island()
-    .set_nav_mesh(Transform::default(), nav_mesh.clone())
+    .set_nav_mesh(Transform::default(), nav_mesh.clone(), HashMap::new())
     .id();
   archipelago
     .add_island()
     .set_nav_mesh(
       Transform { translation: Vec3::new(1.0, 0.0, 0.0), rotation: 0.0 },
       nav_mesh.clone(),
+      HashMap::new(),
     )
     .id();
 
@@ -492,6 +494,7 @@ fn fails_to_draw_dirty_archipelago() {
   archipelago.get_island_mut(island_id).unwrap().set_nav_mesh(
     Transform { translation: Vec3::ZERO, rotation: 0.0 },
     nav_mesh.clone(),
+    HashMap::new(),
   );
   assert_eq!(
     draw_archipelago_debug(&archipelago, &mut fake_drawer),
@@ -506,6 +509,7 @@ fn fails_to_draw_dirty_archipelago() {
   archipelago.get_island_mut(island_id).unwrap().set_nav_mesh(
     Transform { translation: Vec3::ZERO, rotation: 1.0 },
     nav_mesh,
+    HashMap::new(),
   );
   assert_eq!(
     draw_archipelago_debug(&archipelago, &mut fake_drawer),

--- a/crates/landmass/src/debug_test.rs
+++ b/crates/landmass/src/debug_test.rs
@@ -89,6 +89,7 @@ fn draws_island_meshes_and_agents() {
       vec![9, 10, 12, 11],
       vec![10, 4, 14, 13],
     ],
+    polygon_type_indices: vec![0, 0, 0, 0],
   }
   .validate()
   .expect("Mesh is valid.");
@@ -423,6 +424,7 @@ fn draws_boundary_links() {
         Vec3::new(1.0, 2.0, 1.0),
       ],
       polygons: vec![vec![0, 1, 2, 3]],
+      polygon_type_indices: vec![0],
     }
     .validate()
     .expect("The mesh is valid."),
@@ -470,6 +472,7 @@ fn fails_to_draw_dirty_archipelago() {
         Vec3::new(1.0, 2.0, 1.0),
       ],
       polygons: vec![vec![0, 1, 2, 3]],
+      polygon_type_indices: vec![0],
     }
     .validate()
     .expect("The mesh is valid."),

--- a/crates/landmass/src/island.rs
+++ b/crates/landmass/src/island.rs
@@ -63,7 +63,7 @@ impl<CS: CoordinateSystem> Island<CS> {
   /// `type_index_to_node_type` translates the type indices used in `nav_mesh`
   /// into [`NodeType`]s from the [`crate::Archipelago`]. Type indices without a
   /// corresponding node type will be treated as the "default" node type, which
-  /// has a cost of 1.0. See [`crate::Archipelago::create_node_type`] for
+  /// has a cost of 1.0. See [`crate::Archipelago::add_node_type`] for
   /// details on cost. [`NodeType`]s not present in the corresponding
   /// [`crate::Archipelago`] will cause a panic, so do not mix [`NodeType`]s
   /// across [`crate::Archipelago`]s.

--- a/crates/landmass/src/island.rs
+++ b/crates/landmass/src/island.rs
@@ -1,10 +1,10 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use slotmap::new_key_type;
 
 use crate::{
   util::{BoundingBox, Transform},
-  CoordinateSystem, ValidNavigationMesh,
+  CoordinateSystem, NodeType, ValidNavigationMesh,
 };
 
 new_key_type! {
@@ -28,6 +28,9 @@ pub(crate) struct IslandNavigationData<CS: CoordinateSystem> {
   pub(crate) transform: Transform<CS>,
   /// The navigation mesh for the island.
   pub(crate) nav_mesh: Arc<ValidNavigationMesh<CS>>,
+  /// A map from the type indices used by [`Self::nav_mesh`] to the
+  /// [`NodeType`]s used in the [`crate::Archipelago`].
+  pub(crate) type_index_to_node_type: HashMap<usize, NodeType>,
 
   // The bounds of `nav_mesh` after being transformed by `transform`.
   pub(crate) transformed_bounds: BoundingBox,
@@ -49,16 +52,32 @@ impl<CS: CoordinateSystem> Island<CS> {
     self.nav_data.as_ref().map(|d| Arc::clone(&d.nav_mesh))
   }
 
+  /// Gets the current `type_index_to_node_type` used by the island.
+  pub fn get_type_index_to_node_type(
+    &self,
+  ) -> Option<&HashMap<usize, NodeType>> {
+    self.nav_data.as_ref().map(|d| &d.type_index_to_node_type)
+  }
+
   /// Sets the navigation mesh and the transform of the island.
+  /// `type_index_to_node_type` translates the type indices used in `nav_mesh`
+  /// into [`NodeType`]s from the [`crate::Archipelago`]. Type indices without a
+  /// corresponding node type will be treated as the "default" node type, which
+  /// has a cost of 1.0. See [`crate::Archipelago::create_node_type`] for
+  /// details on cost. [`NodeType`]s not present in the corresponding
+  /// [`crate::Archipelago`] will cause a panic, so do not mix [`NodeType`]s
+  /// across [`crate::Archipelago`]s.
   pub fn set_nav_mesh(
     &mut self,
     transform: Transform<CS>,
     nav_mesh: Arc<ValidNavigationMesh<CS>>,
+    type_index_to_node_type: HashMap<usize, NodeType>,
   ) {
     self.nav_data = Some(IslandNavigationData {
       transformed_bounds: nav_mesh.get_bounds().transform(&transform),
       transform,
       nav_mesh,
+      type_index_to_node_type,
     });
     self.dirty = true;
   }

--- a/crates/landmass/src/lib.rs
+++ b/crates/landmass/src/lib.rs
@@ -311,7 +311,7 @@ impl<CS: CoordinateSystem> Archipelago<CS> {
             &self.nav_data,
             agent_node.unwrap(),
             target_node.unwrap(),
-            &HashMap::new(),
+            &agent.override_node_type_to_cost,
           );
 
           self.pathing_results.push(PathingResult {

--- a/crates/landmass/src/lib.rs
+++ b/crates/landmass/src/lib.rs
@@ -211,8 +211,9 @@ impl<CS: CoordinateSystem> Archipelago<CS> {
     &self,
     start_point: &SampledPoint<'_, CS>,
     end_point: &SampledPoint<'_, CS>,
+    override_node_type_costs: &HashMap<NodeType, f32>,
   ) -> Result<Vec<CS::Coordinate>, FindPathError> {
-    query::find_path(self, start_point, end_point)
+    query::find_path(self, start_point, end_point, override_node_type_costs)
   }
 
   pub fn update(&mut self, delta_time: f32) {
@@ -310,6 +311,7 @@ impl<CS: CoordinateSystem> Archipelago<CS> {
             &self.nav_data,
             agent_node.unwrap(),
             target_node.unwrap(),
+            &HashMap::new(),
           );
 
           self.pathing_results.push(PathingResult {

--- a/crates/landmass/src/lib.rs
+++ b/crates/landmass/src/lib.rs
@@ -29,7 +29,7 @@ pub use agent::{Agent, AgentId, AgentState, TargetReachedCondition};
 pub use character::{Character, CharacterId};
 pub use coords::{CoordinateSystem, XYZ};
 pub use island::{Island, IslandId};
-pub use nav_data::IslandMut;
+pub use nav_data::{IslandMut, NodeType};
 pub use nav_mesh::{NavigationMesh, ValidNavigationMesh, ValidationError};
 pub use query::{FindPathError, SamplePointError, SampledPoint};
 pub use util::Transform;
@@ -155,6 +155,36 @@ impl<CS: CoordinateSystem> Archipelago<CS> {
 
   pub fn get_island_ids(&self) -> impl ExactSizeIterator<Item = IslandId> + '_ {
     self.nav_data.get_island_ids()
+  }
+
+  /// Creates a new node type with the specified `cost`. The cost is a
+  /// multiplier on the distance travelled along this node (essentially the cost
+  /// per meter). Agents will prefer to travel along low-cost terrain. The
+  /// returned node type is distinct from all other node types (for this
+  /// archipelago).
+  pub fn create_node_type(&mut self, cost: f32) -> NodeType {
+    self.nav_data.create_node_type(cost)
+  }
+
+  /// Sets the cost of `node_type` to `cost`. See
+  /// [`Archipelago::create_node_type`] for the meaning of cost. Returns
+  /// false if the node type does not exist in this archipelago. Otherwise,
+  /// returns true.
+  pub fn set_node_type_cost(&mut self, node_type: NodeType, cost: f32) -> bool {
+    self.nav_data.set_node_type_cost(node_type, cost)
+  }
+
+  /// Gets the cost of `node_type`. Returns [`None`] if `node_type` is not in
+  /// this archipelago.
+  pub fn get_node_type_cost(&self, node_type: NodeType) -> Option<f32> {
+    self.nav_data.get_node_type_cost(node_type)
+  }
+
+  /// Removes the node type from the archipelago. Returns false if this
+  /// archipelago does not contain `node_type` or any islands still use this
+  /// node type (so the node type cannot be removed). Otherwise, returns true.
+  pub fn remove_node_type(&mut self, node_type: NodeType) -> bool {
+    self.nav_data.remove_node_type(node_type)
   }
 
   /// Gets the pathing results from the last [`Self::update`] call.

--- a/crates/landmass/src/lib.rs
+++ b/crates/landmass/src/lib.rs
@@ -29,7 +29,7 @@ pub use agent::{Agent, AgentId, AgentState, TargetReachedCondition};
 pub use character::{Character, CharacterId};
 pub use coords::{CoordinateSystem, XYZ};
 pub use island::{Island, IslandId};
-pub use nav_data::{IslandMut, NodeType};
+pub use nav_data::{IslandMut, NewNodeTypeError, NodeType};
 pub use nav_mesh::{NavigationMesh, ValidNavigationMesh, ValidationError};
 pub use query::{FindPathError, SamplePointError, SampledPoint};
 pub use util::Transform;
@@ -161,8 +161,11 @@ impl<CS: CoordinateSystem> Archipelago<CS> {
   /// multiplier on the distance travelled along this node (essentially the cost
   /// per meter). Agents will prefer to travel along low-cost terrain. The
   /// returned node type is distinct from all other node types (for this
-  /// archipelago). Returns an error if the cost is <= 0.0.
-  pub fn add_node_type(&mut self, cost: f32) -> Result<NodeType, ()> {
+  /// archipelago).
+  pub fn add_node_type(
+    &mut self,
+    cost: f32,
+  ) -> Result<NodeType, NewNodeTypeError> {
     self.nav_data.add_node_type(cost)
   }
 

--- a/crates/landmass/src/lib.rs
+++ b/crates/landmass/src/lib.rs
@@ -161,15 +161,15 @@ impl<CS: CoordinateSystem> Archipelago<CS> {
   /// multiplier on the distance travelled along this node (essentially the cost
   /// per meter). Agents will prefer to travel along low-cost terrain. The
   /// returned node type is distinct from all other node types (for this
-  /// archipelago).
-  pub fn create_node_type(&mut self, cost: f32) -> NodeType {
+  /// archipelago). Returns an error if the cost is <= 0.0.
+  pub fn create_node_type(&mut self, cost: f32) -> Result<NodeType, ()> {
     self.nav_data.create_node_type(cost)
   }
 
   /// Sets the cost of `node_type` to `cost`. See
   /// [`Archipelago::create_node_type`] for the meaning of cost. Returns
-  /// false if the node type does not exist in this archipelago. Otherwise,
-  /// returns true.
+  /// false if the node type does not exist in this archipelago, or the cost is
+  /// <= 0.0. Otherwise, returns true.
   pub fn set_node_type_cost(&mut self, node_type: NodeType, cost: f32) -> bool {
     self.nav_data.set_node_type_cost(node_type, cost)
   }

--- a/crates/landmass/src/lib.rs
+++ b/crates/landmass/src/lib.rs
@@ -162,12 +162,12 @@ impl<CS: CoordinateSystem> Archipelago<CS> {
   /// per meter). Agents will prefer to travel along low-cost terrain. The
   /// returned node type is distinct from all other node types (for this
   /// archipelago). Returns an error if the cost is <= 0.0.
-  pub fn create_node_type(&mut self, cost: f32) -> Result<NodeType, ()> {
-    self.nav_data.create_node_type(cost)
+  pub fn add_node_type(&mut self, cost: f32) -> Result<NodeType, ()> {
+    self.nav_data.add_node_type(cost)
   }
 
   /// Sets the cost of `node_type` to `cost`. See
-  /// [`Archipelago::create_node_type`] for the meaning of cost. Returns
+  /// [`Archipelago::add_node_type`] for the meaning of cost. Returns
   /// false if the node type does not exist in this archipelago, or the cost is
   /// <= 0.0. Otherwise, returns true.
   pub fn set_node_type_cost(&mut self, node_type: NodeType, cost: f32) -> bool {

--- a/crates/landmass/src/lib.rs
+++ b/crates/landmass/src/lib.rs
@@ -29,7 +29,9 @@ pub use agent::{Agent, AgentId, AgentState, TargetReachedCondition};
 pub use character::{Character, CharacterId};
 pub use coords::{CoordinateSystem, XYZ};
 pub use island::{Island, IslandId};
-pub use nav_data::{IslandMut, NewNodeTypeError, NodeType};
+pub use nav_data::{
+  IslandMut, NewNodeTypeError, NodeType, SetNodeTypeCostError,
+};
 pub use nav_mesh::{NavigationMesh, ValidNavigationMesh, ValidationError};
 pub use query::{FindPathError, SamplePointError, SampledPoint};
 pub use util::Transform;
@@ -170,10 +172,12 @@ impl<CS: CoordinateSystem> Archipelago<CS> {
   }
 
   /// Sets the cost of `node_type` to `cost`. See
-  /// [`Archipelago::add_node_type`] for the meaning of cost. Returns
-  /// false if the node type does not exist in this archipelago, or the cost is
-  /// <= 0.0. Otherwise, returns true.
-  pub fn set_node_type_cost(&mut self, node_type: NodeType, cost: f32) -> bool {
+  /// [`Archipelago::add_node_type`] for the meaning of cost.
+  pub fn set_node_type_cost(
+    &mut self,
+    node_type: NodeType,
+    cost: f32,
+  ) -> Result<(), SetNodeTypeCostError> {
     self.nav_data.set_node_type_cost(node_type, cost)
   }
 

--- a/crates/landmass/src/lib_test.rs
+++ b/crates/landmass/src/lib_test.rs
@@ -538,7 +538,7 @@ fn finds_path() {
     .sample_point(offset + Vec2::new(2.5, 1.25), 1e-5)
     .expect("point is on nav mesh.");
   assert_eq!(
-    archipelago.find_path(&start_point, &end_point),
+    archipelago.find_path(&start_point, &end_point, &HashMap::new()),
     Ok(vec![
       offset + Vec2::new(0.5, 0.5),
       offset + Vec2::new(2.0, 1.0),

--- a/crates/landmass/src/lib_test.rs
+++ b/crates/landmass/src/lib_test.rs
@@ -4,9 +4,8 @@ use glam::{Vec2, Vec3};
 
 use crate::{
   coords::{XY, XYZ},
-  util::BoundingBox,
   Agent, AgentId, AgentState, Archipelago, Character, CharacterId, IslandId,
-  NavigationMesh, Transform, ValidNavigationMesh,
+  NavigationMesh, Transform,
 };
 
 #[test]
@@ -418,13 +417,9 @@ fn changed_island_is_not_dirty_after_update() {
 
   archipelago.get_island_mut(island_id).unwrap().set_nav_mesh(
     Transform::default(),
-    Arc::new(ValidNavigationMesh {
-      mesh_bounds: BoundingBox::Empty,
-      boundary_edges: vec![],
-      polygons: vec![],
-      vertices: vec![],
-      marker: Default::default(),
-    }),
+    Arc::new(
+      NavigationMesh { polygons: vec![], vertices: vec![] }.validate().unwrap(),
+    ),
   );
 
   assert!(archipelago.get_island(island_id).unwrap().dirty);

--- a/crates/landmass/src/lib_test.rs
+++ b/crates/landmass/src/lib_test.rs
@@ -161,6 +161,7 @@ fn computes_and_follows_path() {
       vec![4, 5, 8, 9],
       vec![5, 6, 7, 8],
     ],
+    polygon_type_indices: vec![0, 0, 0, 0, 0],
   }
   .validate()
   .expect("is valid");
@@ -418,7 +419,13 @@ fn changed_island_is_not_dirty_after_update() {
   archipelago.get_island_mut(island_id).unwrap().set_nav_mesh(
     Transform::default(),
     Arc::new(
-      NavigationMesh { polygons: vec![], vertices: vec![] }.validate().unwrap(),
+      NavigationMesh {
+        vertices: vec![],
+        polygons: vec![],
+        polygon_type_indices: vec![],
+      }
+      .validate()
+      .unwrap(),
     ),
   );
 
@@ -442,6 +449,7 @@ fn samples_point() {
         Vec2::new(0.0, 1.0),
       ],
       polygons: vec![vec![0, 1, 2, 3]],
+      polygon_type_indices: vec![0],
     }
     .validate()
     .expect("nav mesh is valid"),
@@ -495,6 +503,7 @@ fn finds_path() {
         Vec2::new(0.0, 1.0),
       ],
       polygons: vec![vec![0, 1, 2, 3]],
+      polygon_type_indices: vec![0],
     }
     .validate()
     .expect("nav mesh is valid"),

--- a/crates/landmass/src/lib_test.rs
+++ b/crates/landmass/src/lib_test.rs
@@ -596,7 +596,7 @@ fn agent_overrides_node_costs() {
     .expect("nav mesh is valid"),
   );
 
-  let node_type = archipelago.create_node_type(1.0).unwrap();
+  let node_type = archipelago.add_node_type(1.0).unwrap();
 
   archipelago.add_island().set_nav_mesh(
     Transform::default(),

--- a/crates/landmass/src/lib_test.rs
+++ b/crates/landmass/src/lib_test.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use glam::{Vec2, Vec3};
 
@@ -169,6 +169,7 @@ fn computes_and_follows_path() {
   archipelago.add_island().set_nav_mesh(
     Transform { translation: Vec3::ZERO, rotation: 0.0 },
     Arc::new(nav_mesh),
+    HashMap::new(),
   );
 
   archipelago.agent_options.neighbourhood = 0.0;
@@ -427,6 +428,7 @@ fn changed_island_is_not_dirty_after_update() {
       .validate()
       .unwrap(),
     ),
+    HashMap::new(),
   );
 
   assert!(archipelago.get_island(island_id).unwrap().dirty);
@@ -456,9 +458,11 @@ fn samples_point() {
   );
 
   let offset = Vec2::new(10.0, 10.0);
-  archipelago
-    .add_island()
-    .set_nav_mesh(Transform { translation: offset, rotation: 0.0 }, nav_mesh);
+  archipelago.add_island().set_nav_mesh(
+    Transform { translation: offset, rotation: 0.0 },
+    nav_mesh,
+    HashMap::new(),
+  );
   archipelago.update(1.0);
 
   assert_eq!(
@@ -513,14 +517,17 @@ fn finds_path() {
   archipelago.add_island().set_nav_mesh(
     Transform { translation: offset, rotation: 0.0 },
     nav_mesh.clone(),
+    HashMap::new(),
   );
   archipelago.add_island().set_nav_mesh(
     Transform { translation: offset + Vec2::new(1.0, 0.0), rotation: 0.0 },
     nav_mesh.clone(),
+    HashMap::new(),
   );
   archipelago.add_island().set_nav_mesh(
     Transform { translation: offset + Vec2::new(2.0, 0.5), rotation: 0.0 },
     nav_mesh,
+    HashMap::new(),
   );
   archipelago.update(1.0);
 

--- a/crates/landmass/src/nav_data.rs
+++ b/crates/landmass/src/nav_data.rs
@@ -701,15 +701,23 @@ impl<CS: CoordinateSystem> IslandMut<'_, CS> {
     self.id
   }
 
-  /// Sets the navigation mesh and the transform of the island. This matches
+  /// Sets the navigation mesh and the transform of the island.
+  /// `type_index_to_node_type` translates the type indices used in `nav_mesh`
+  /// into [`NodeType`]s from the [`crate::Archipelago`]. Type indices without a
+  /// corresponding node type will be treated as the "default" node type, which
+  /// has a cost of 1.0. See [`crate::Archipelago::create_node_type`] for
+  /// details on cost. [`NodeType`]s not present in the corresponding
+  /// [`crate::Archipelago`] will cause a panic, so do not mix [`NodeType`]s
+  /// across [`crate::Archipelago`]s. This matches
   /// [`crate::Island::set_nav_mesh`], but returns self for convenience.
   pub fn set_nav_mesh(
     &mut self,
     transform: Transform<CS>,
     nav_mesh: Arc<ValidNavigationMesh<CS>>,
+    type_index_to_node_type: HashMap<usize, NodeType>,
   ) -> &mut Self {
     // Deref so we automatically trigger any change detection stuff.
-    self.deref_mut().set_nav_mesh(transform, nav_mesh);
+    self.deref_mut().set_nav_mesh(transform, nav_mesh, type_index_to_node_type);
     self
   }
 }

--- a/crates/landmass/src/nav_data.rs
+++ b/crates/landmass/src/nav_data.rs
@@ -125,7 +125,7 @@ impl<CS: CoordinateSystem> NavigationData<CS> {
   /// per meter). Agents will prefer to travel along low-cost terrain. This node
   /// type is distinct from all other node types. Returns an error if the cost
   /// is <= 0.0.
-  pub(crate) fn create_node_type(&mut self, cost: f32) -> Result<NodeType, ()> {
+  pub(crate) fn add_node_type(&mut self, cost: f32) -> Result<NodeType, ()> {
     if cost <= 0.0 {
       return Err(());
     }
@@ -133,7 +133,7 @@ impl<CS: CoordinateSystem> NavigationData<CS> {
   }
 
   /// Sets the cost of `node_type` to `cost`. See
-  /// [`NavigationData::create_node_type`] for the meaning of cost. Returns
+  /// [`NavigationData::add_node_type`] for the meaning of cost. Returns
   /// false if the node type does not exist in this nav data, or the cost is <=
   /// 0.0. Otherwise, returns true.
   pub(crate) fn set_node_type_cost(
@@ -750,7 +750,7 @@ impl<CS: CoordinateSystem> IslandMut<'_, CS> {
   /// `type_index_to_node_type` translates the type indices used in `nav_mesh`
   /// into [`NodeType`]s from the [`crate::Archipelago`]. Type indices without a
   /// corresponding node type will be treated as the "default" node type, which
-  /// has a cost of 1.0. See [`crate::Archipelago::create_node_type`] for
+  /// has a cost of 1.0. See [`crate::Archipelago::add_node_type`] for
   /// details on cost. [`NodeType`]s not present in the corresponding
   /// [`crate::Archipelago`] will cause a panic, so do not mix [`NodeType`]s
   /// across [`crate::Archipelago`]s. This matches

--- a/crates/landmass/src/nav_data.rs
+++ b/crates/landmass/src/nav_data.rs
@@ -151,7 +151,26 @@ impl<CS: CoordinateSystem> NavigationData<CS> {
       return false;
     }
 
-    todo!()
+    for island in self.islands.values() {
+      let Some(nav_data) = island.nav_data.as_ref() else {
+        continue;
+      };
+
+      for type_index in nav_data.nav_mesh.used_type_indices.iter() {
+        let Some(island_node_type) =
+          nav_data.type_index_to_node_type.get(type_index)
+        else {
+          continue;
+        };
+
+        if *island_node_type == node_type {
+          return false;
+        }
+      }
+    }
+
+    self.node_type_to_cost.remove(node_type);
+    true
   }
 
   /// Gets the current node types and their costs.

--- a/crates/landmass/src/nav_data.rs
+++ b/crates/landmass/src/nav_data.rs
@@ -123,20 +123,27 @@ impl<CS: CoordinateSystem> NavigationData<CS> {
   /// Creates a new node type with the specified `cost`. The cost is a
   /// multiplier on the distance travelled along this node (essentially the cost
   /// per meter). Agents will prefer to travel along low-cost terrain. This node
-  /// type is distinct from all other node types.
-  pub(crate) fn create_node_type(&mut self, cost: f32) -> NodeType {
-    self.node_type_to_cost.insert(cost)
+  /// type is distinct from all other node types. Returns an error if the cost
+  /// is <= 0.0.
+  pub(crate) fn create_node_type(&mut self, cost: f32) -> Result<NodeType, ()> {
+    if cost <= 0.0 {
+      return Err(());
+    }
+    Ok(self.node_type_to_cost.insert(cost))
   }
 
   /// Sets the cost of `node_type` to `cost`. See
   /// [`NavigationData::create_node_type`] for the meaning of cost. Returns
-  /// false if the node type does not exist in this nav data. Otherwise,
-  /// returns true.
+  /// false if the node type does not exist in this nav data, or the cost is <=
+  /// 0.0. Otherwise, returns true.
   pub(crate) fn set_node_type_cost(
     &mut self,
     node_type: NodeType,
     cost: f32,
   ) -> bool {
+    if cost <= 0.0 {
+      return false;
+    }
     let Some(node_type_cost) = self.node_type_to_cost.get_mut(node_type) else {
       return false;
     };

--- a/crates/landmass/src/nav_data.rs
+++ b/crates/landmass/src/nav_data.rs
@@ -367,6 +367,18 @@ impl<CS: CoordinateSystem> NavigationData<CS> {
         None => continue,
         Some(n) => n,
       };
+      // Check that all the island's node types are valid.
+      for type_index in dirty_nav_data.nav_mesh.used_type_indices.iter() {
+        if let Some(&node_type) =
+          dirty_nav_data.type_index_to_node_type.get(type_index)
+        {
+          assert!(
+            self.node_type_to_cost.contains_key(node_type),
+            "Island {dirty_island_id:?} uses node type {node_type:?} which is not in this navigation data."
+          );
+        }
+      }
+
       if dirty_nav_data.nav_mesh.boundary_edges.is_empty() {
         continue;
       }

--- a/crates/landmass/src/nav_data_test.rs
+++ b/crates/landmass/src/nav_data_test.rs
@@ -1003,15 +1003,15 @@ fn empty_navigation_mesh_is_safe() {
 #[test]
 fn error_on_create_zero_or_negative_node_type() {
   let mut archipelago = Archipelago::<XY>::new();
-  assert_eq!(archipelago.create_node_type(0.0), Err(()));
-  assert_eq!(archipelago.create_node_type(-1.0), Err(()));
+  assert_eq!(archipelago.add_node_type(0.0), Err(()));
+  assert_eq!(archipelago.add_node_type(-1.0), Err(()));
 }
 
 #[test]
 fn false_on_setting_zero_or_negative_node_type() {
   let mut archipelago = Archipelago::<XY>::new();
 
-  let node_type = archipelago.create_node_type(1.0).unwrap();
+  let node_type = archipelago.add_node_type(1.0).unwrap();
 
   assert_eq!(archipelago.set_node_type_cost(node_type, 0.0), false);
   assert_eq!(archipelago.set_node_type_cost(node_type, -1.0), false);
@@ -1021,8 +1021,8 @@ fn false_on_setting_zero_or_negative_node_type() {
 fn cannot_remove_used_node_type() {
   let mut archipelago = Archipelago::<XY>::new();
 
-  let node_type_1 = archipelago.create_node_type(2.0).unwrap();
-  let node_type_2 = archipelago.create_node_type(3.0).unwrap();
+  let node_type_1 = archipelago.add_node_type(2.0).unwrap();
+  let node_type_2 = archipelago.add_node_type(3.0).unwrap();
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -1101,7 +1101,7 @@ fn cannot_remove_used_node_type() {
 #[should_panic]
 fn panics_on_invalid_node_type() {
   let mut archipelago = Archipelago::<XY>::new();
-  let deleted_node_type = archipelago.create_node_type(2.0).unwrap();
+  let deleted_node_type = archipelago.add_node_type(2.0).unwrap();
   assert!(archipelago.remove_node_type(deleted_node_type));
 
   let nav_mesh = Arc::new(

--- a/crates/landmass/src/nav_data_test.rs
+++ b/crates/landmass/src/nav_data_test.rs
@@ -13,7 +13,7 @@ use crate::{
   island::Island,
   nav_data::{BoundaryLink, NodeRef},
   nav_mesh::NavigationMesh,
-  Archipelago, IslandId, NodeType, Transform,
+  Archipelago, IslandId, NewNodeTypeError, NodeType, Transform,
 };
 
 use super::{
@@ -1003,8 +1003,14 @@ fn empty_navigation_mesh_is_safe() {
 #[test]
 fn error_on_create_zero_or_negative_node_type() {
   let mut archipelago = Archipelago::<XY>::new();
-  assert_eq!(archipelago.add_node_type(0.0), Err(()));
-  assert_eq!(archipelago.add_node_type(-1.0), Err(()));
+  assert_eq!(
+    archipelago.add_node_type(0.0),
+    Err(NewNodeTypeError::NonPositiveCost(0.0))
+  );
+  assert_eq!(
+    archipelago.add_node_type(-1.0),
+    Err(NewNodeTypeError::NonPositiveCost(-1.0))
+  );
 }
 
 #[test]

--- a/crates/landmass/src/nav_data_test.rs
+++ b/crates/landmass/src/nav_data_test.rs
@@ -47,6 +47,7 @@ fn samples_points() {
     .set_nav_mesh(
       Transform { translation: Vec3::ZERO, rotation: 0.0 },
       Arc::clone(&nav_mesh),
+      HashMap::new(),
     )
     .id();
   let island_id_2 = nav_data
@@ -54,6 +55,7 @@ fn samples_points() {
     .set_nav_mesh(
       Transform { translation: Vec3::new(5.0, 0.0, 0.1), rotation: PI * 0.5 },
       Arc::clone(&nav_mesh),
+      HashMap::new(),
     )
     .id();
 
@@ -221,8 +223,16 @@ fn link_edges_between_islands_links_touching_islands() {
 
   let transform =
     Transform { translation: Vec3::new(1.0, 2.0, 3.0), rotation: PI * -0.25 };
-  island_1.set_nav_mesh(transform.clone(), Arc::clone(&nav_mesh_1));
-  island_2.set_nav_mesh(transform.clone(), Arc::clone(&nav_mesh_2));
+  island_1.set_nav_mesh(
+    transform.clone(),
+    Arc::clone(&nav_mesh_1),
+    HashMap::new(),
+  );
+  island_2.set_nav_mesh(
+    transform.clone(),
+    Arc::clone(&nav_mesh_2),
+    HashMap::new(),
+  );
 
   let island_1_edge_bbh = island_edges_bbh(island_1.nav_data.as_ref().unwrap());
   let island_2_edge_bbh = island_edges_bbh(island_2.nav_data.as_ref().unwrap());
@@ -499,6 +509,7 @@ fn update_links_islands_and_unlinks_on_delete() {
     .set_nav_mesh(
       Transform { translation: Vec3::ZERO, rotation: 0.0 },
       Arc::clone(&nav_mesh),
+      HashMap::new(),
     )
     .id();
   let island_2_id = nav_data
@@ -506,6 +517,7 @@ fn update_links_islands_and_unlinks_on_delete() {
     .set_nav_mesh(
       Transform { translation: Vec3::ZERO, rotation: PI * 0.5 },
       Arc::clone(&nav_mesh),
+      HashMap::new(),
     )
     .id();
   let island_3_id = nav_data
@@ -513,6 +525,7 @@ fn update_links_islands_and_unlinks_on_delete() {
     .set_nav_mesh(
       Transform { translation: Vec3::ZERO, rotation: PI },
       Arc::clone(&nav_mesh),
+      HashMap::new(),
     )
     .id();
   let island_4_id = nav_data
@@ -520,6 +533,7 @@ fn update_links_islands_and_unlinks_on_delete() {
     .set_nav_mesh(
       Transform { translation: Vec3::new(3.0, 0.0, 0.0), rotation: PI },
       Arc::clone(&nav_mesh),
+      HashMap::new(),
     )
     .id();
   let island_5_id = nav_data
@@ -527,6 +541,7 @@ fn update_links_islands_and_unlinks_on_delete() {
     .set_nav_mesh(
       Transform { translation: Vec3::new(2.0, 3.0, 0.0), rotation: PI * -0.5 },
       Arc::clone(&nav_mesh),
+      HashMap::new(),
     )
     .id();
 
@@ -648,6 +663,7 @@ fn update_links_islands_and_unlinks_on_delete() {
     .set_nav_mesh(
       Transform { translation: Vec3::ZERO, rotation: PI * 0.5 },
       Arc::clone(&nav_mesh),
+      HashMap::new(),
     );
 
   nav_data.update(/* edge_link_distance= */ 0.01);
@@ -802,6 +818,7 @@ fn modifies_node_boundaries_for_linked_islands() {
     .set_nav_mesh(
       Transform { translation: Vec3::ZERO, rotation: 0.0 },
       Arc::clone(&nav_mesh),
+      HashMap::new(),
     )
     .id();
   let island_2_id = nav_data
@@ -809,6 +826,7 @@ fn modifies_node_boundaries_for_linked_islands() {
     .set_nav_mesh(
       Transform { translation: Vec3::new(1.0, -1.0, 0.0), rotation: 0.0 },
       Arc::clone(&nav_mesh),
+      HashMap::new(),
     )
     .id();
   let island_3_id = nav_data
@@ -816,6 +834,7 @@ fn modifies_node_boundaries_for_linked_islands() {
     .set_nav_mesh(
       Transform { translation: Vec3::new(2.0, 3.5, 0.0), rotation: PI * -0.5 },
       Arc::clone(&nav_mesh),
+      HashMap::new(),
     )
     .id();
 
@@ -877,12 +896,14 @@ fn stale_modified_nodes_are_removed() {
   nav_data.add_island().set_nav_mesh(
     Transform { translation: Vec3::ZERO, rotation: 0.0 },
     Arc::clone(&nav_mesh),
+    HashMap::new(),
   );
   let island_2_id = nav_data
     .add_island()
     .set_nav_mesh(
       Transform { translation: Vec3::new(1.0, -1.0, 0.0), rotation: 0.0 },
       Arc::clone(&nav_mesh),
+      HashMap::new(),
     )
     .id();
 
@@ -925,8 +946,16 @@ fn empty_navigation_mesh_is_safe() {
   );
 
   let mut nav_data = NavigationData::<XYZ>::new();
-  nav_data.add_island().set_nav_mesh(Transform::default(), full_nav_mesh);
-  nav_data.add_island().set_nav_mesh(Transform::default(), empty_nav_mesh);
+  nav_data.add_island().set_nav_mesh(
+    Transform::default(),
+    full_nav_mesh,
+    HashMap::new(),
+  );
+  nav_data.add_island().set_nav_mesh(
+    Transform::default(),
+    empty_nav_mesh,
+    HashMap::new(),
+  );
 
   // Nothing should panic here.
   nav_data.update(/* edge_link_distance= */ 1e-6);

--- a/crates/landmass/src/nav_data_test.rs
+++ b/crates/landmass/src/nav_data_test.rs
@@ -1001,11 +1001,28 @@ fn empty_navigation_mesh_is_safe() {
 }
 
 #[test]
+fn error_on_create_zero_or_negative_node_type() {
+  let mut archipelago = Archipelago::<XY>::new();
+  assert_eq!(archipelago.create_node_type(0.0), Err(()));
+  assert_eq!(archipelago.create_node_type(-1.0), Err(()));
+}
+
+#[test]
+fn false_on_setting_zero_or_negative_node_type() {
+  let mut archipelago = Archipelago::<XY>::new();
+
+  let node_type = archipelago.create_node_type(1.0).unwrap();
+
+  assert_eq!(archipelago.set_node_type_cost(node_type, 0.0), false);
+  assert_eq!(archipelago.set_node_type_cost(node_type, -1.0), false);
+}
+
+#[test]
 fn cannot_remove_used_node_type() {
   let mut archipelago = Archipelago::<XY>::new();
 
-  let node_type_1 = archipelago.create_node_type(2.0);
-  let node_type_2 = archipelago.create_node_type(3.0);
+  let node_type_1 = archipelago.create_node_type(2.0).unwrap();
+  let node_type_2 = archipelago.create_node_type(3.0).unwrap();
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -1084,7 +1101,7 @@ fn cannot_remove_used_node_type() {
 #[should_panic]
 fn panics_on_invalid_node_type() {
   let mut archipelago = Archipelago::<XY>::new();
-  let deleted_node_type = archipelago.create_node_type(2.0);
+  let deleted_node_type = archipelago.create_node_type(2.0).unwrap();
   assert!(archipelago.remove_node_type(deleted_node_type));
 
   let nav_mesh = Arc::new(

--- a/crates/landmass/src/nav_data_test.rs
+++ b/crates/landmass/src/nav_data_test.rs
@@ -13,7 +13,8 @@ use crate::{
   island::Island,
   nav_data::{BoundaryLink, NodeRef},
   nav_mesh::NavigationMesh,
-  Archipelago, IslandId, NewNodeTypeError, NodeType, Transform,
+  Archipelago, IslandId, NewNodeTypeError, NodeType, SetNodeTypeCostError,
+  Transform,
 };
 
 use super::{
@@ -1019,8 +1020,14 @@ fn false_on_setting_zero_or_negative_node_type() {
 
   let node_type = archipelago.add_node_type(1.0).unwrap();
 
-  assert_eq!(archipelago.set_node_type_cost(node_type, 0.0), false);
-  assert_eq!(archipelago.set_node_type_cost(node_type, -1.0), false);
+  assert_eq!(
+    archipelago.set_node_type_cost(node_type, 0.0),
+    Err(SetNodeTypeCostError::NonPositiveCost(0.0))
+  );
+  assert_eq!(
+    archipelago.set_node_type_cost(node_type, -1.0),
+    Err(SetNodeTypeCostError::NonPositiveCost(-1.0))
+  );
 }
 
 #[test]

--- a/crates/landmass/src/nav_data_test.rs
+++ b/crates/landmass/src/nav_data_test.rs
@@ -35,6 +35,7 @@ fn samples_points() {
       Vec3::new(1.0, 2.0, 1.0),
     ],
     polygons: vec![vec![0, 1, 6, 7], vec![1, 2, 5, 6], vec![2, 3, 4, 5]],
+    polygon_type_indices: vec![0, 0, 0],
   }
   .validate()
   .expect("is valid");
@@ -175,6 +176,7 @@ fn link_edges_between_islands_links_touching_islands() {
         vec![10, 11, 5, 4],
         vec![6, 0, 5, 11],
       ],
+      polygon_type_indices: vec![0, 0, 0, 0, 0, 0],
     }
     .validate()
     .expect("is valid."),
@@ -203,6 +205,7 @@ fn link_edges_between_islands_links_touching_islands() {
         vec![5, 6, 9, 8],
         vec![10, 11, 2, 1],
       ],
+      polygon_type_indices: vec![0, 0, 0, 0, 0],
     }
     .validate()
     .expect("is valid."),
@@ -483,6 +486,7 @@ fn update_links_islands_and_unlinks_on_delete() {
         Vec3::new(1.0, 1.0, 1.0),
       ],
       polygons: vec![vec![0, 1, 2, 5], vec![4, 5, 2, 3]],
+      polygon_type_indices: vec![0, 0],
     }
     .validate()
     .expect("is valid."),
@@ -785,6 +789,7 @@ fn modifies_node_boundaries_for_linked_islands() {
         Vec3::new(1.0, 3.0, 1.0),
       ],
       polygons: vec![vec![0, 1, 2, 3], vec![3, 2, 4, 5]],
+      polygon_type_indices: vec![0, 0],
     }
     .validate()
     .expect("is valid."),
@@ -861,6 +866,7 @@ fn stale_modified_nodes_are_removed() {
         Vec3::new(1.0, 3.0, 1.0),
       ],
       polygons: vec![vec![0, 1, 2, 3], vec![3, 2, 4, 5]],
+      polygon_type_indices: vec![0, 0],
     }
     .validate()
     .expect("is valid."),
@@ -902,15 +908,20 @@ fn empty_navigation_mesh_is_safe() {
         Vec3::new(0.0, 1.0, 0.0),
       ],
       polygons: vec![vec![0, 1, 2, 3]],
+      polygon_type_indices: vec![0],
     }
     .validate()
     .expect("A square nav mesh is valid."),
   );
 
   let empty_nav_mesh = Arc::new(
-    NavigationMesh { vertices: vec![], polygons: vec![] }
-      .validate()
-      .expect("An empty nav mesh is valid."),
+    NavigationMesh {
+      vertices: vec![],
+      polygons: vec![],
+      polygon_type_indices: vec![],
+    }
+    .validate()
+    .expect("An empty nav mesh is valid."),
   );
 
   let mut nav_data = NavigationData::<XYZ>::new();

--- a/crates/landmass/src/nav_data_test.rs
+++ b/crates/landmass/src/nav_data_test.rs
@@ -1079,3 +1079,35 @@ fn cannot_remove_used_node_type() {
     [(node_type_2, 3.0)]
   );
 }
+
+#[test]
+#[should_panic]
+fn panics_on_invalid_node_type() {
+  let mut archipelago = Archipelago::<XY>::new();
+  let deleted_node_type = archipelago.create_node_type(2.0);
+  assert!(archipelago.remove_node_type(deleted_node_type));
+
+  let nav_mesh = Arc::new(
+    NavigationMesh {
+      vertices: vec![
+        Vec2::new(0.0, 0.0),
+        Vec2::new(1.0, 0.0),
+        Vec2::new(1.0, 1.0),
+        Vec2::new(0.0, 1.0),
+      ],
+      polygons: vec![vec![0, 1, 2, 3]],
+      polygon_type_indices: vec![0],
+    }
+    .validate()
+    .expect("mesh is valid"),
+  );
+
+  archipelago.add_island().set_nav_mesh(
+    Transform::default(),
+    nav_mesh,
+    HashMap::from([(0, deleted_node_type)]),
+  );
+
+  // Panics due to referencing invalid node type.
+  archipelago.update(1.0);
+}

--- a/crates/landmass/src/nav_mesh.rs
+++ b/crates/landmass/src/nav_mesh.rs
@@ -239,12 +239,16 @@ impl<CS: CoordinateSystem> NavigationMesh<CS> {
         } => {
           let edge = polygons[polygon_1].get_edge_indices(edge_1);
           let edge_center = (vertices[edge.0] + vertices[edge.1]) / 2.0;
-          let cost = polygons[polygon_1].center.distance(edge_center)
-            + polygons[polygon_2].center.distance(edge_center);
+          let travel_distances = (
+            polygons[polygon_1].center.distance(edge_center),
+            polygons[polygon_2].center.distance(edge_center),
+          );
           polygons[polygon_1].connectivity[edge_1] =
-            Some(Connectivity { polygon_index: polygon_2, cost });
-          polygons[polygon_2].connectivity[edge_2] =
-            Some(Connectivity { polygon_index: polygon_1, cost });
+            Some(Connectivity { polygon_index: polygon_2, travel_distances });
+          polygons[polygon_2].connectivity[edge_2] = Some(Connectivity {
+            polygon_index: polygon_1,
+            travel_distances: (travel_distances.1, travel_distances.0),
+          });
         }
       }
     }
@@ -342,8 +346,11 @@ pub(crate) struct ValidPolygon {
 pub(crate) struct Connectivity {
   /// The index of the polygon that this edge leads to.
   pub(crate) polygon_index: usize,
-  /// The cost of travelling across this connection.
-  pub(crate) cost: f32,
+  /// The distances of travelling across this connection. The first is the
+  /// distance travelled across the starting node, and the second is the
+  /// distance travelled across the destination node. These must be multiplied
+  /// by the actual node costs.
+  pub(crate) travel_distances: (f32, f32),
 }
 
 /// A reference to an edge on a navigation mesh.

--- a/crates/landmass/src/nav_mesh.rs
+++ b/crates/landmass/src/nav_mesh.rs
@@ -20,8 +20,8 @@ pub struct NavigationMesh<CS: CoordinateSystem> {
   /// not self-intersecting.
   pub polygons: Vec<Vec<usize>>,
   /// The type index of each polygon. This type index is translated into a real
-  /// "node type" when assigned to an [`crate::Archipelago`]. Must be the same
-  /// length as [`Self::polygons`].
+  /// [`crate::NodeType`] when assigned to an [`crate::Archipelago`]. Must be
+  /// the same length as [`Self::polygons`].
   pub polygon_type_indices: Vec<usize>,
 }
 

--- a/crates/landmass/src/nav_mesh_test.rs
+++ b/crates/landmass/src/nav_mesh_test.rs
@@ -294,23 +294,57 @@ fn derives_connectivity_and_boundary_edges() {
 
   // Each edge has a cost of node 1 to its edge (always 0.5), and each other
   // node to its edge.
-  let cost_01 =
-    0.5 + Vec2::new(2.0 / 3.0, 1.0 / 3.0).distance(Vec2::new(1.0, 0.5));
-  let cost_12 =
-    0.5 + Vec3::new(2.5, 0.5, 0.5).distance(Vec3::new(2.0, 0.5, 0.0));
-  let cost_13 =
-    0.5 + Vec3::new(1.5, 1.5, 0.5).distance(Vec3::new(1.5, 1.0, 0.0));
+  let travel_distances_01 =
+    (Vec2::new(2.0 / 3.0, 1.0 / 3.0).distance(Vec2::new(1.0, 0.5)), 0.5);
+  let travel_distances_12 =
+    (0.5, Vec3::new(2.5, 0.5, 0.5).distance(Vec3::new(2.0, 0.5, 0.0)));
+  let travel_distances_13 =
+    (0.5, Vec3::new(1.5, 1.5, 0.5).distance(Vec3::new(1.5, 1.0, 0.0)));
+
+  let flip = |(a, b): (f32, f32)| (b, a);
 
   let expected_connectivity: [&[_]; 4] = [
-    &[None, Some(Connectivity { polygon_index: 1, cost: cost_01 }), None],
     &[
       None,
-      Some(Connectivity { polygon_index: 2, cost: cost_12 }),
-      Some(Connectivity { polygon_index: 3, cost: cost_13 }),
-      Some(Connectivity { polygon_index: 0, cost: cost_01 }),
+      Some(Connectivity {
+        polygon_index: 1,
+        travel_distances: travel_distances_01,
+      }),
+      None,
     ],
-    &[None, None, None, Some(Connectivity { polygon_index: 1, cost: cost_12 })],
-    &[Some(Connectivity { polygon_index: 1, cost: cost_13 }), None, None, None],
+    &[
+      None,
+      Some(Connectivity {
+        polygon_index: 2,
+        travel_distances: travel_distances_12,
+      }),
+      Some(Connectivity {
+        polygon_index: 3,
+        travel_distances: travel_distances_13,
+      }),
+      Some(Connectivity {
+        polygon_index: 0,
+        travel_distances: flip(travel_distances_01),
+      }),
+    ],
+    &[
+      None,
+      None,
+      None,
+      Some(Connectivity {
+        polygon_index: 1,
+        travel_distances: flip(travel_distances_12),
+      }),
+    ],
+    &[
+      Some(Connectivity {
+        polygon_index: 1,
+        travel_distances: flip(travel_distances_13),
+      }),
+      None,
+      None,
+      None,
+    ],
   ];
   assert_eq!(
     valid_mesh

--- a/crates/landmass/src/path_test.rs
+++ b/crates/landmass/src/path_test.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashSet, f32::consts::PI, sync::Arc};
+use std::{
+  collections::{HashMap, HashSet},
+  f32::consts::PI,
+  sync::Arc,
+};
 
 use glam::{Vec2, Vec3};
 use slotmap::HopSlotMap;
@@ -71,7 +75,7 @@ fn finds_next_point_for_organic_map() {
   let mut archipelago = Archipelago::<XYZ>::new();
   let island_id = archipelago
     .add_island()
-    .set_nav_mesh(transform.clone(), Arc::new(nav_mesh))
+    .set_nav_mesh(transform.clone(), Arc::new(nav_mesh), HashMap::new())
     .id();
 
   let path = Path {
@@ -176,7 +180,7 @@ fn finds_next_point_in_zig_zag() {
   let mut archipelago = Archipelago::<XY>::new();
   let island_id = archipelago
     .add_island()
-    .set_nav_mesh(transform.clone(), Arc::new(nav_mesh))
+    .set_nav_mesh(transform.clone(), Arc::new(nav_mesh), HashMap::new())
     .id();
 
   let path = Path {
@@ -252,6 +256,7 @@ fn starts_at_end_index_goes_to_end_point() {
     .set_nav_mesh(
       Transform { translation: Vec3::ZERO, rotation: 0.0 },
       Arc::new(nav_mesh),
+      HashMap::new(),
     )
     .id();
 

--- a/crates/landmass/src/path_test.rs
+++ b/crates/landmass/src/path_test.rs
@@ -61,6 +61,7 @@ fn finds_next_point_for_organic_map() {
       vec![9, 10, 12, 11],
       vec![10, 4, 14, 13],
     ],
+    polygon_type_indices: vec![0, 0, 0, 0],
   }
   .validate()
   .expect("Mesh is valid.");
@@ -165,6 +166,7 @@ fn finds_next_point_in_zig_zag() {
       vec![24, 23, 25],
       vec![25, 23, 26, 27],
     ],
+    polygon_type_indices: vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
   }
   .validate()
   .expect("Mesh is valid.");
@@ -239,6 +241,7 @@ fn starts_at_end_index_goes_to_end_point() {
       Vec3::new(0.0, 2.0, 0.0),
     ],
     polygons: vec![vec![0, 1, 2, 3], vec![3, 2, 4, 5]],
+    polygon_type_indices: vec![0, 0],
   }
   .validate()
   .expect("Mesh is valid.");

--- a/crates/landmass/src/pathfinding.rs
+++ b/crates/landmass/src/pathfinding.rs
@@ -101,7 +101,18 @@ impl<CS: CoordinateSystem> AStarProblem for ArchipelagoPathProblem<'_, CS> {
       })
       .chain(boundary_links.iter().map(|link_id| {
         let link = self.nav_data.boundary_links.get(*link_id).unwrap();
-        (link.cost, PathStep::BoundaryLink(*link_id), link.destination_node)
+        let destination_node_cost = link
+          .destination_node_type
+          .map(|node_type| {
+            self
+              .nav_data
+              .get_node_type_cost(node_type)
+              .expect("Node type exists.")
+          })
+          .unwrap_or(1.0);
+        let cost = link.travel_distances.0 * current_node_cost
+          + link.travel_distances.1 * destination_node_cost;
+        (cost, PathStep::BoundaryLink(*link_id), link.destination_node)
       }))
       .collect()
   }

--- a/crates/landmass/src/pathfinding_test.rs
+++ b/crates/landmass/src/pathfinding_test.rs
@@ -38,6 +38,7 @@ fn finds_path_in_archipelago() {
       vec![9, 10, 12, 11],
       vec![10, 4, 14, 13],
     ],
+    polygon_type_indices: vec![0, 0, 0, 0],
   }
   .validate()
   .expect("Mesh is valid.");
@@ -134,6 +135,7 @@ fn finds_paths_on_two_islands() {
       vec![9, 10, 12, 11],
       vec![10, 4, 14, 13],
     ],
+    polygon_type_indices: vec![0, 0, 0, 0],
   }
   .validate()
   .expect("Mesh is valid.");
@@ -221,6 +223,7 @@ fn no_path_between_disconnected_islands() {
       vec![9, 10, 12, 11],
       vec![10, 4, 14, 13],
     ],
+    polygon_type_indices: vec![0, 0, 0, 0],
   }
   .validate()
   .expect("Mesh is valid.");
@@ -273,6 +276,7 @@ fn find_path_across_connected_islands() {
         Vec3::new(-0.5, 0.5, 0.0),
       ],
       polygons: vec![vec![0, 1, 2, 3]],
+      polygon_type_indices: vec![0],
     }
     .validate()
     .expect("Mesh is valid."),
@@ -388,6 +392,7 @@ fn finds_path_across_different_islands() {
         Vec3::new(-0.5, 0.5, 0.0),
       ],
       polygons: vec![vec![0, 1, 2, 3]],
+      polygon_type_indices: vec![0],
     }
     .validate()
     .expect("Mesh is valid."),
@@ -403,6 +408,7 @@ fn finds_path_across_different_islands() {
         Vec3::new(1.5, 0.5, 0.0),
       ],
       polygons: vec![vec![0, 1, 2, 3], vec![2, 1, 4, 5]],
+      polygon_type_indices: vec![0, 0],
     }
     .validate()
     .expect("Mesh is valid."),
@@ -479,6 +485,7 @@ fn aborts_early_for_unconnected_regions() {
         Vec3::new(-0.5, 1.5, 0.0),
       ],
       polygons: vec![vec![0, 1, 2, 3]],
+      polygon_type_indices: vec![0],
     }
     .validate()
     .expect("Mesh is valid."),

--- a/crates/landmass/src/pathfinding_test.rs
+++ b/crates/landmass/src/pathfinding_test.rs
@@ -885,7 +885,7 @@ fn infinite_or_nan_cost_cannot_find_path() {
   assert_eq!(path_result.path, None);
   assert_eq!(path_result.stats.explored_nodes, 1);
 
-  archipelago.set_node_type_cost(node_type, f32::NAN);
+  archipelago.set_node_type_cost(node_type, f32::NAN).unwrap();
 
   let path_result = find_path(
     &archipelago.nav_data,

--- a/crates/landmass/src/pathfinding_test.rs
+++ b/crates/landmass/src/pathfinding_test.rs
@@ -617,7 +617,7 @@ fn detour_for_high_cost_path() {
     .expect("nav mesh is valid"),
   );
 
-  let slow_node_type = archipelago.create_node_type(10.0).unwrap();
+  let slow_node_type = archipelago.add_node_type(10.0).unwrap();
 
   let island_id = archipelago
     .add_island()
@@ -706,7 +706,7 @@ fn detour_for_high_cost_path_across_boundary_links() {
     .expect("nav mesh is valid"),
   );
 
-  let slow_node_type = archipelago.create_node_type(5.1).unwrap();
+  let slow_node_type = archipelago.add_node_type(5.1).unwrap();
 
   let island_id_1 = archipelago
     .add_island()
@@ -809,7 +809,7 @@ fn fast_path_not_ignored_by_heuristic() {
   );
 
   // This node type is faster than default.
-  let fast_type = archipelago.create_node_type(0.5).unwrap();
+  let fast_type = archipelago.add_node_type(0.5).unwrap();
 
   let island_id = archipelago
     .add_island()
@@ -864,7 +864,7 @@ fn infinite_or_nan_cost_cannot_find_path() {
     .expect("mesh is valid"),
   );
 
-  let node_type = archipelago.create_node_type(f32::INFINITY).unwrap();
+  let node_type = archipelago.add_node_type(f32::INFINITY).unwrap();
 
   let island_id = archipelago
     .add_island()
@@ -948,7 +948,7 @@ fn detour_for_overridden_high_cost_path() {
     .expect("nav mesh is valid"),
   );
 
-  let slow_node_type = archipelago.create_node_type(1.0).unwrap();
+  let slow_node_type = archipelago.add_node_type(1.0).unwrap();
 
   let island_id = archipelago
     .add_island()

--- a/crates/landmass/src/pathfinding_test.rs
+++ b/crates/landmass/src/pathfinding_test.rs
@@ -49,6 +49,7 @@ fn finds_path_in_archipelago() {
     .set_nav_mesh(
       Transform { translation: Vec3::ZERO, rotation: 0.0 },
       Arc::new(nav_mesh),
+      HashMap::new(),
     )
     .id();
 
@@ -147,6 +148,7 @@ fn finds_paths_on_two_islands() {
     .set_nav_mesh(
       Transform { translation: Vec3::ZERO, rotation: 0.0 },
       Arc::clone(&nav_mesh),
+      HashMap::new(),
     )
     .id();
 
@@ -155,6 +157,7 @@ fn finds_paths_on_two_islands() {
     .set_nav_mesh(
       Transform { translation: Vec3::new(6.0, 0.0, 0.0), rotation: PI * -0.5 },
       Arc::clone(&nav_mesh),
+      HashMap::new(),
     )
     .id();
 
@@ -235,6 +238,7 @@ fn no_path_between_disconnected_islands() {
     .set_nav_mesh(
       Transform { translation: Vec3::ZERO, rotation: 0.0 },
       Arc::clone(&nav_mesh),
+      HashMap::new(),
     )
     .id();
 
@@ -243,6 +247,7 @@ fn no_path_between_disconnected_islands() {
     .set_nav_mesh(
       Transform { translation: Vec3::new(6.0, 0.0, 0.0), rotation: PI * -0.5 },
       Arc::clone(&nav_mesh),
+      HashMap::new(),
     )
     .id();
 
@@ -289,6 +294,7 @@ fn find_path_across_connected_islands() {
     .set_nav_mesh(
       Transform { rotation: 0.0, translation: Vec3::ZERO },
       Arc::clone(&nav_mesh),
+      HashMap::new(),
     )
     .id();
   let island_id_2 = archipelago
@@ -296,18 +302,21 @@ fn find_path_across_connected_islands() {
     .set_nav_mesh(
       Transform { rotation: 0.0, translation: Vec3::new(1.0, 0.0, 0.0) },
       Arc::clone(&nav_mesh),
+      HashMap::new(),
     )
     .id();
   // island_id_3 is unused.
   archipelago.add_island().set_nav_mesh(
     Transform { rotation: 0.0, translation: Vec3::new(1.0, -1.0, 0.0) },
     Arc::clone(&nav_mesh),
+    HashMap::new(),
   );
   let island_id_4 = archipelago
     .add_island()
     .set_nav_mesh(
       Transform { rotation: 0.0, translation: Vec3::new(1.0, 1.0, 0.0) },
       Arc::clone(&nav_mesh),
+      HashMap::new(),
     )
     .id();
   let island_id_5 = archipelago
@@ -315,6 +324,7 @@ fn find_path_across_connected_islands() {
     .set_nav_mesh(
       Transform { rotation: 0.0, translation: Vec3::new(1.0, 2.0, 0.0) },
       Arc::clone(&nav_mesh),
+      HashMap::new(),
     )
     .id();
 
@@ -421,6 +431,7 @@ fn finds_path_across_different_islands() {
     .set_nav_mesh(
       Transform { rotation: 0.0, translation: Vec3::ZERO },
       nav_mesh_1,
+      HashMap::new(),
     )
     .id();
   let island_id_2 = archipelago
@@ -428,6 +439,7 @@ fn finds_path_across_different_islands() {
     .set_nav_mesh(
       Transform { rotation: 0.0, translation: Vec3::new(1.0, 0.0, 0.0) },
       nav_mesh_2,
+      HashMap::new(),
     )
     .id();
 
@@ -498,6 +510,7 @@ fn aborts_early_for_unconnected_regions() {
     .set_nav_mesh(
       Transform { translation: Vec3::ZERO, rotation: 0.0 },
       nav_mesh.clone(),
+      HashMap::new(),
     )
     .id();
   let island_id_2 = archipelago
@@ -505,6 +518,7 @@ fn aborts_early_for_unconnected_regions() {
     .set_nav_mesh(
       Transform { translation: Vec3::new(2.0, 0.0, 0.0), rotation: 0.0 },
       nav_mesh.clone(),
+      HashMap::new(),
     )
     .id();
   let island_id_3 = archipelago
@@ -512,6 +526,7 @@ fn aborts_early_for_unconnected_regions() {
     .set_nav_mesh(
       Transform { translation: Vec3::new(1.5, 2.0, 0.0), rotation: PI * 0.5 },
       nav_mesh.clone(),
+      HashMap::new(),
     )
     .id();
 

--- a/crates/landmass/src/pathfinding_test.rs
+++ b/crates/landmass/src/pathfinding_test.rs
@@ -606,7 +606,7 @@ fn detour_for_high_cost_path() {
     .expect("nav mesh is valid"),
   );
 
-  let slow_node_type = archipelago.create_node_type(10.0);
+  let slow_node_type = archipelago.create_node_type(10.0).unwrap();
 
   let island_id = archipelago
     .add_island()
@@ -694,7 +694,7 @@ fn detour_for_high_cost_path_across_boundary_links() {
     .expect("nav mesh is valid"),
   );
 
-  let slow_node_type = archipelago.create_node_type(5.1);
+  let slow_node_type = archipelago.create_node_type(5.1).unwrap();
 
   let island_id_1 = archipelago
     .add_island()
@@ -796,7 +796,7 @@ fn fast_path_not_ignored_by_heuristic() {
   );
 
   // This node type is faster than default.
-  let fast_type = archipelago.create_node_type(0.5);
+  let fast_type = archipelago.create_node_type(0.5).unwrap();
 
   let island_id = archipelago
     .add_island()
@@ -850,7 +850,7 @@ fn infinite_or_nan_cost_cannot_find_path() {
     .expect("mesh is valid"),
   );
 
-  let node_type = archipelago.create_node_type(f32::INFINITY);
+  let node_type = archipelago.create_node_type(f32::INFINITY).unwrap();
 
   let island_id = archipelago
     .add_island()

--- a/crates/landmass/src/query_test.rs
+++ b/crates/landmass/src/query_test.rs
@@ -22,6 +22,7 @@ fn error_on_dirty_nav_mesh() {
         Vec2::new(0.0, 1.0),
       ],
       polygons: vec![vec![0, 1, 2, 3]],
+      polygon_type_indices: vec![0],
     }
     .validate()
     .expect("nav mesh is valid"),
@@ -52,6 +53,7 @@ fn error_on_out_of_range() {
         Vec2::new(0.0, 1.0),
       ],
       polygons: vec![vec![0, 1, 2, 3]],
+      polygon_type_indices: vec![0],
     }
     .validate()
     .expect("nav mesh is valid"),
@@ -84,6 +86,7 @@ fn samples_point_on_nav_mesh_or_near_nav_mesh() {
         Vec2::new(0.0, 1.0),
       ],
       polygons: vec![vec![0, 1, 2, 3]],
+      polygon_type_indices: vec![0],
     }
     .validate()
     .expect("nav mesh is valid"),
@@ -137,6 +140,7 @@ fn no_path() {
         Vec2::new(0.0, 1.0),
       ],
       polygons: vec![vec![0, 1, 2, 3]],
+      polygon_type_indices: vec![0],
     }
     .validate()
     .expect("nav mesh is valid"),
@@ -178,6 +182,7 @@ fn finds_path() {
         Vec2::new(0.0, 1.0),
       ],
       polygons: vec![vec![0, 1, 2, 3]],
+      polygon_type_indices: vec![0],
     }
     .validate()
     .expect("nav mesh is valid"),

--- a/crates/landmass/src/query_test.rs
+++ b/crates/landmass/src/query_test.rs
@@ -176,7 +176,7 @@ fn no_path() {
     .sample_point(offset + Vec2::new(2.5, 0.5), 1e-5)
     .expect("point is on nav mesh.");
   assert_eq!(
-    find_path(&archipelago, &start_point, &end_point),
+    find_path(&archipelago, &start_point, &end_point, &HashMap::new()),
     Err(FindPathError::NoPathFound)
   );
 }
@@ -225,11 +225,158 @@ fn finds_path() {
     .sample_point(offset + Vec2::new(2.5, 1.25), 1e-5)
     .expect("point is on nav mesh.");
   assert_eq!(
-    find_path(&archipelago, &start_point, &end_point),
+    find_path(&archipelago, &start_point, &end_point, &HashMap::new()),
     Ok(vec![
       offset + Vec2::new(0.5, 0.5),
       offset + Vec2::new(2.0, 1.0),
       offset + Vec2::new(2.5, 1.25)
     ])
+  );
+}
+
+#[test]
+fn finds_path_with_override_node_types() {
+  let mut archipelago = Archipelago::<XY>::new();
+
+  let nav_mesh = Arc::new(
+    NavigationMesh {
+      vertices: vec![
+        Vec2::new(0.0, 0.0),
+        Vec2::new(1.0, 0.0),
+        Vec2::new(1.0, 1.0),
+        Vec2::new(0.0, 1.0),
+        //
+        Vec2::new(2.0, 0.0),
+        Vec2::new(2.0, 1.0),
+        //
+        Vec2::new(3.0, 0.0),
+        Vec2::new(3.0, 1.0),
+        //
+        Vec2::new(2.0, 11.0),
+        Vec2::new(3.0, 11.0),
+        //
+        Vec2::new(2.0, 12.0),
+        Vec2::new(3.0, 12.0),
+        //
+        Vec2::new(1.0, 12.0),
+        Vec2::new(1.0, 11.0),
+        //
+        Vec2::new(0.0, 12.0),
+        Vec2::new(0.0, 11.0),
+      ],
+      polygons: vec![
+        vec![0, 1, 2, 3],
+        vec![2, 1, 4, 5],
+        vec![5, 4, 6, 7],
+        //
+        vec![5, 7, 9, 8],
+        vec![8, 9, 11, 10],
+        //
+        vec![8, 10, 12, 13],
+        vec![13, 12, 14, 15],
+        //
+        vec![3, 2, 13, 15],
+      ],
+      polygon_type_indices: vec![0, 0, 0, 0, 0, 0, 0, 1],
+    }
+    .validate()
+    .expect("nav mesh is valid"),
+  );
+
+  let node_type = archipelago.create_node_type(1.0).unwrap();
+
+  archipelago.add_island().set_nav_mesh(
+    Transform::default(),
+    nav_mesh,
+    HashMap::from([(1, node_type)]),
+  );
+
+  archipelago.update(1.0);
+
+  let start_point = sample_point(
+    &archipelago,
+    Vec2::new(0.5, 0.5),
+    /* distance_to_node= */ 0.1,
+  )
+  .unwrap();
+  let end_point = sample_point(
+    &archipelago,
+    Vec2::new(0.5, 11.5),
+    /* distance_to_node= */ 0.1,
+  )
+  .unwrap();
+
+  let path = find_path(
+    &archipelago,
+    &start_point,
+    &end_point,
+    &HashMap::from([(node_type, 10.0)]),
+  )
+  .expect("Path found");
+
+  assert_eq!(
+    path,
+    [
+      Vec2::new(0.5, 0.5),
+      Vec2::new(2.0, 1.0),
+      Vec2::new(2.0, 11.0),
+      Vec2::new(0.5, 11.5)
+    ]
+  );
+}
+
+#[test]
+fn find_path_returns_error_on_invalid_node_cost() {
+  let mut archipelago = Archipelago::<XY>::new();
+
+  let nav_mesh = Arc::new(
+    NavigationMesh {
+      vertices: vec![
+        Vec2::new(0.0, 0.0),
+        Vec2::new(1.0, 0.0),
+        Vec2::new(1.0, 1.0),
+        Vec2::new(0.0, 1.0),
+      ],
+      polygons: vec![vec![0, 1, 2, 3]],
+      polygon_type_indices: vec![0],
+    }
+    .validate()
+    .expect("nav mesh is valid"),
+  );
+
+  let node_type = archipelago.create_node_type(1.0).unwrap();
+
+  archipelago.add_island().set_nav_mesh(
+    Transform::default(),
+    nav_mesh,
+    HashMap::from([(0, node_type)]),
+  );
+
+  archipelago.update(1.0);
+
+  let start_point = archipelago
+    .sample_point(Vec2::new(0.25, 0.25), /* distance_to_node= */ 0.1)
+    .unwrap();
+  let end_point = archipelago
+    .sample_point(Vec2::new(0.25, 0.25), /* distance_to_node= */ 0.1)
+    .unwrap();
+
+  assert_eq!(
+    find_path(
+      &archipelago,
+      &start_point,
+      &end_point,
+      &HashMap::from([(node_type, 0.0)]),
+    ),
+    Err(FindPathError::NonPositiveNodeTypeCost(node_type, 0.0))
+  );
+  assert_eq!(
+    find_path(
+      &archipelago,
+      &start_point,
+      &end_point,
+      &HashMap::from([(node_type, -0.5)]),
+    ),
+    Err(FindPathError::NonPositiveNodeTypeCost(node_type, -0.5))
   );
 }

--- a/crates/landmass/src/query_test.rs
+++ b/crates/landmass/src/query_test.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use glam::Vec2;
 
@@ -28,7 +28,11 @@ fn error_on_dirty_nav_mesh() {
     .expect("nav mesh is valid"),
   );
 
-  archipelago.add_island().set_nav_mesh(Transform::default(), nav_mesh);
+  archipelago.add_island().set_nav_mesh(
+    Transform::default(),
+    nav_mesh,
+    HashMap::new(),
+  );
   assert_eq!(
     sample_point(
       &archipelago,
@@ -59,7 +63,11 @@ fn error_on_out_of_range() {
     .expect("nav mesh is valid"),
   );
 
-  archipelago.add_island().set_nav_mesh(Transform::default(), nav_mesh);
+  archipelago.add_island().set_nav_mesh(
+    Transform::default(),
+    nav_mesh,
+    HashMap::new(),
+  );
   archipelago.update(1.0);
 
   assert_eq!(
@@ -93,9 +101,11 @@ fn samples_point_on_nav_mesh_or_near_nav_mesh() {
   );
 
   let offset = Vec2::new(10.0, 10.0);
-  archipelago
-    .add_island()
-    .set_nav_mesh(Transform { translation: offset, rotation: 0.0 }, nav_mesh);
+  archipelago.add_island().set_nav_mesh(
+    Transform { translation: offset, rotation: 0.0 },
+    nav_mesh,
+    HashMap::new(),
+  );
   archipelago.update(1.0);
 
   assert_eq!(
@@ -150,10 +160,12 @@ fn no_path() {
   archipelago.add_island().set_nav_mesh(
     Transform { translation: offset, rotation: 0.0 },
     nav_mesh.clone(),
+    HashMap::new(),
   );
   archipelago.add_island().set_nav_mesh(
     Transform { translation: offset + Vec2::new(2.0, 0.0), rotation: 0.0 },
     nav_mesh,
+    HashMap::new(),
   );
   archipelago.update(1.0);
 
@@ -192,14 +204,17 @@ fn finds_path() {
   archipelago.add_island().set_nav_mesh(
     Transform { translation: offset, rotation: 0.0 },
     nav_mesh.clone(),
+    HashMap::new(),
   );
   archipelago.add_island().set_nav_mesh(
     Transform { translation: offset + Vec2::new(1.0, 0.0), rotation: 0.0 },
     nav_mesh.clone(),
+    HashMap::new(),
   );
   archipelago.add_island().set_nav_mesh(
     Transform { translation: offset + Vec2::new(2.0, 0.5), rotation: 0.0 },
     nav_mesh,
+    HashMap::new(),
   );
   archipelago.update(1.0);
 

--- a/crates/landmass/src/query_test.rs
+++ b/crates/landmass/src/query_test.rs
@@ -283,7 +283,7 @@ fn finds_path_with_override_node_types() {
     .expect("nav mesh is valid"),
   );
 
-  let node_type = archipelago.create_node_type(1.0).unwrap();
+  let node_type = archipelago.add_node_type(1.0).unwrap();
 
   archipelago.add_island().set_nav_mesh(
     Transform::default(),
@@ -344,7 +344,7 @@ fn find_path_returns_error_on_invalid_node_cost() {
     .expect("nav mesh is valid"),
   );
 
-  let node_type = archipelago.create_node_type(1.0).unwrap();
+  let node_type = archipelago.add_node_type(1.0).unwrap();
 
   archipelago.add_island().set_nav_mesh(
     Transform::default(),


### PR DESCRIPTION
This allows users to have some areas take longer to navigate, and having the pathfinding algorithm avoid these regions. Similarly, some nodes may be faster to navigate and so should be preferred.

# Overview

* Every `NavigationMesh` records a "type index" for each polygon. This is propagated to the `Polygon`s in `ValidNavigationMesh`.
* When adding a navigation mesh to an island, you also have to specify a map from the type indices to the actual node type.
* Node types are created in the archipelago.
* You can change the cost of node types at runtime, and even assign "override node type costs" to agents.