### PR TITLE
Make islands transient.

### DIFF
--- a/crates/bevy_landmass/src/lib.rs
+++ b/crates/bevy_landmass/src/lib.rs
@@ -99,18 +99,14 @@ impl<CS: CoordinateSystem> Plugin for LandmassPlugin<CS> {
       Update,
       (
         add_agents_to_archipelagos::<CS>,
-        add_islands_to_archipelago::<CS>,
+        sync_islands_to_archipelago::<CS>,
         add_characters_to_archipelago::<CS>,
       )
         .in_set(LandmassSystemSet::SyncExistence),
     );
     app.add_systems(
       Update,
-      (
-        sync_agent_input_state::<CS>,
-        sync_island_nav_mesh::<CS>,
-        sync_character_state::<CS>,
-      )
+      (sync_agent_input_state::<CS>, sync_character_state::<CS>)
         .in_set(LandmassSystemSet::SyncValues),
     );
     app.add_systems(

--- a/crates/bevy_landmass/src/lib_test.rs
+++ b/crates/bevy_landmass/src/lib_test.rs
@@ -330,13 +330,27 @@ fn adds_and_removes_islands() {
 
   let archipelago_id = app.world_mut().spawn(Archipelago3d::new()).id();
 
+  let nav_mesh =
+    app.world_mut().resource_mut::<Assets<NavMesh3d>>().add(NavMesh3d {
+      nav_mesh: Arc::new(
+        NavigationMesh {
+          vertices: vec![],
+          polygons: vec![],
+          polygon_type_indices: vec![],
+        }
+        .validate()
+        .unwrap(),
+      ),
+      type_index_to_node_type: HashMap::new(),
+    });
+
   let island_id_1 = app
     .world_mut()
     .spawn(TransformBundle::default())
     .insert(Island3dBundle {
       island: Island,
       archipelago_ref: ArchipelagoRef3d::new(archipelago_id),
-      nav_mesh: Default::default(),
+      nav_mesh: nav_mesh.clone(),
     })
     .id();
 
@@ -346,7 +360,7 @@ fn adds_and_removes_islands() {
     .insert(Island3dBundle {
       island: Island,
       archipelago_ref: ArchipelagoRef3d::new(archipelago_id),
-      nav_mesh: Default::default(),
+      nav_mesh: nav_mesh.clone(),
     })
     .id();
 
@@ -374,7 +388,7 @@ fn adds_and_removes_islands() {
     .insert(Island3dBundle {
       island: Island,
       archipelago_ref: ArchipelagoRef3d::new(archipelago_id),
-      nav_mesh: Default::default(),
+      nav_mesh: nav_mesh.clone(),
     })
     .id();
 

--- a/crates/landmass/README.md
+++ b/crates/landmass/README.md
@@ -73,13 +73,11 @@ let valid_nav_mesh = Arc::new(
 );
 
 let island_id = archipelago
-  .add_island()
-  .set_nav_mesh(
+  .add_island(Island::new(
     Transform { translation: Vec3::ZERO, rotation: 0.0 },
     valid_nav_mesh,
     HashMap::new(),
-  )
-  .id();
+  ));
 
 let agent_1 = archipelago.add_agent({
   let mut agent = Agent::create(

--- a/crates/landmass/src/agent_test.rs
+++ b/crates/landmass/src/agent_test.rs
@@ -12,7 +12,7 @@ use crate::{
   coords::{XY, XYZ},
   nav_data::NodeRef,
   path::{IslandSegment, Path, PathIndex},
-  Agent, Archipelago, IslandId, NavigationMesh, NodeType,
+  Agent, Archipelago, Island, IslandId, NavigationMesh, NodeType,
   TargetReachedCondition, Transform,
 };
 
@@ -82,10 +82,11 @@ fn has_reached_target_at_end_node() {
   let transform =
     Transform { translation: Vec3::new(2.0, 3.0, 4.0), rotation: PI * 0.85 };
   let mut archipelago = Archipelago::<XYZ>::new();
-  let island_id = archipelago
-    .add_island()
-    .set_nav_mesh(transform.clone(), Arc::new(nav_mesh), HashMap::new())
-    .id();
+  let island_id = archipelago.add_island(Island::new(
+    transform.clone(),
+    Arc::new(nav_mesh),
+    HashMap::new(),
+  ));
   let mut agent = Agent::create(
     /* position= */ transform.apply(Vec3::new(1.0, 0.0, 1.0)),
     /* velocity= */ Vec3::ZERO,
@@ -157,10 +158,11 @@ fn long_detour_reaches_target_in_different_ways() {
   let transform =
     Transform { translation: Vec3::new(2.0, 4.0, 3.0), rotation: PI * -0.85 };
   let mut archipelago = Archipelago::<XYZ>::new();
-  let island_id = archipelago
-    .add_island()
-    .set_nav_mesh(transform.clone(), Arc::new(nav_mesh), HashMap::new())
-    .id();
+  let island_id = archipelago.add_island(Island::new(
+    transform.clone(),
+    Arc::new(nav_mesh),
+    HashMap::new(),
+  ));
 
   let mut agent = Agent::create(
     /* position= */ Vec3::ZERO,

--- a/crates/landmass/src/avoidance_test.rs
+++ b/crates/landmass/src/avoidance_test.rs
@@ -5,7 +5,7 @@ use slotmap::HopSlotMap;
 
 use crate::{
   avoidance::apply_avoidance_to_agents, coords::XYZ, nav_data::NodeRef, Agent,
-  AgentId, AgentOptions, Character, CharacterId, NavigationData,
+  AgentId, AgentOptions, Character, CharacterId, Island, NavigationData,
   NavigationMesh, Transform,
 };
 
@@ -84,14 +84,11 @@ fn computes_obstacle_for_box() {
   let island_offset_dodgy =
     dodgy_2d::Vec2::new(island_offset.x, island_offset.y);
 
-  let island_id = nav_data
-    .add_island()
-    .set_nav_mesh(
-      Transform { translation: island_offset, rotation: 0.0 },
-      Arc::new(nav_mesh),
-      HashMap::new(),
-    )
-    .id();
+  let island_id = nav_data.add_island(Island::new(
+    Transform { translation: island_offset, rotation: 0.0 },
+    Arc::new(nav_mesh),
+    HashMap::new(),
+  ));
 
   assert_obstacles_match!(
     nav_mesh_borders_to_dodgy_obstacles(
@@ -143,14 +140,11 @@ fn dead_end_makes_open_obstacle() {
   .expect("Validation succeeds");
 
   let mut nav_data = NavigationData::<XYZ>::new();
-  let island_id = nav_data
-    .add_island()
-    .set_nav_mesh(
-      Transform { translation: Vec3::ZERO, rotation: 0.0 },
-      Arc::new(nav_mesh),
-      HashMap::new(),
-    )
-    .id();
+  let island_id = nav_data.add_island(Island::new(
+    Transform { translation: Vec3::ZERO, rotation: 0.0 },
+    Arc::new(nav_mesh),
+    HashMap::new(),
+  ));
 
   assert_obstacles_match!(
     nav_mesh_borders_to_dodgy_obstacles(
@@ -289,14 +283,11 @@ fn split_borders() {
   .expect("Validation succeeds");
 
   let mut nav_data = NavigationData::<XYZ>::new();
-  let island_id = nav_data
-    .add_island()
-    .set_nav_mesh(
-      Transform { translation: Vec3::ZERO, rotation: 0.0 },
-      Arc::new(nav_mesh),
-      HashMap::new(),
-    )
-    .id();
+  let island_id = nav_data.add_island(Island::new(
+    Transform { translation: Vec3::ZERO, rotation: 0.0 },
+    Arc::new(nav_mesh),
+    HashMap::new(),
+  ));
 
   assert_obstacles_match!(
     nav_mesh_borders_to_dodgy_obstacles(
@@ -351,19 +342,16 @@ fn creates_obstacles_across_boundary_link() {
   );
 
   let mut nav_data = NavigationData::<XYZ>::new();
-  nav_data.add_island().set_nav_mesh(
+  nav_data.add_island(Island::new(
     Transform { translation: Vec3::ZERO, rotation: 0.0 },
     Arc::clone(&nav_mesh),
     HashMap::new(),
-  );
-  let island_id_2 = nav_data
-    .add_island()
-    .set_nav_mesh(
-      Transform { translation: Vec3::new(1.0, 0.0, 0.0), rotation: 0.0 },
-      nav_mesh,
-      HashMap::new(),
-    )
-    .id();
+  ));
+  let island_id_2 = nav_data.add_island(Island::new(
+    Transform { translation: Vec3::new(1.0, 0.0, 0.0), rotation: 0.0 },
+    nav_mesh,
+    HashMap::new(),
+  ));
 
   nav_data.update(0.01);
 
@@ -413,14 +401,11 @@ fn applies_no_avoidance_for_far_agents() {
   .expect("Validation succeeded.");
 
   let mut nav_data = NavigationData::<XYZ>::new();
-  let island_id = nav_data
-    .add_island()
-    .set_nav_mesh(
-      Transform { translation: Vec3::ZERO, rotation: 0.0 },
-      Arc::new(nav_mesh),
-      HashMap::new(),
-    )
-    .id();
+  let island_id = nav_data.add_island(Island::new(
+    Transform { translation: Vec3::ZERO, rotation: 0.0 },
+    Arc::new(nav_mesh),
+    HashMap::new(),
+  ));
 
   let mut agents = HopSlotMap::<AgentId, _>::with_key();
   let agent_1 = agents.insert({
@@ -511,14 +496,11 @@ fn applies_avoidance_for_two_agents() {
   .expect("Validation succeeded.");
 
   let mut nav_data = NavigationData::<XYZ>::new();
-  let island_id = nav_data
-    .add_island()
-    .set_nav_mesh(
-      Transform { translation: Vec3::ZERO, rotation: 0.0 },
-      Arc::new(nav_mesh),
-      HashMap::new(),
-    )
-    .id();
+  let island_id = nav_data.add_island(Island::new(
+    Transform { translation: Vec3::ZERO, rotation: 0.0 },
+    Arc::new(nav_mesh),
+    HashMap::new(),
+  ));
 
   let mut agents = HopSlotMap::<AgentId, _>::with_key();
   let agent_1 = agents.insert({
@@ -607,14 +589,11 @@ fn agent_avoids_character() {
   .expect("Validation succeeded.");
 
   let mut nav_data = NavigationData::<XYZ>::new();
-  let island_id = nav_data
-    .add_island()
-    .set_nav_mesh(
-      Transform { translation: Vec3::ZERO, rotation: 0.0 },
-      Arc::new(nav_mesh),
-      HashMap::new(),
-    )
-    .id();
+  let island_id = nav_data.add_island(Island::new(
+    Transform { translation: Vec3::ZERO, rotation: 0.0 },
+    Arc::new(nav_mesh),
+    HashMap::new(),
+  ));
 
   let mut agents = HopSlotMap::<AgentId, _>::with_key();
   let agent = agents.insert({

--- a/crates/landmass/src/island.rs
+++ b/crates/landmass/src/island.rs
@@ -12,18 +12,8 @@ new_key_type! {
   pub struct IslandId;
 }
 
-/// An Island in an Archipelago. Islands are the region that an navigation mesh
-/// can be put into.
+/// An Island in an Archipelago. Each island holds a navigation mesh.
 pub struct Island<CS: CoordinateSystem> {
-  /// The navigation data, if present. May be missing for islands that have not
-  /// finished loading yet, or are having their data updated.
-  pub(crate) nav_data: Option<IslandNavigationData<CS>>,
-  /// Whether the island has been updated recently.
-  pub(crate) dirty: bool,
-}
-
-/// The navigation data of an island.
-pub(crate) struct IslandNavigationData<CS: CoordinateSystem> {
   /// The transform from the Island's frame to the Archipelago's frame.
   pub(crate) transform: Transform<CS>,
   /// The navigation mesh for the island.
@@ -32,60 +22,74 @@ pub(crate) struct IslandNavigationData<CS: CoordinateSystem> {
   /// [`NodeType`]s used in the [`crate::Archipelago`].
   pub(crate) type_index_to_node_type: HashMap<usize, NodeType>,
 
-  // The bounds of `nav_mesh` after being transformed by `transform`.
+  /// The bounds of `nav_mesh` after being transformed by `transform`.
   pub(crate) transformed_bounds: BoundingBox,
+  /// Whether the island has been updated recently.
+  pub(crate) dirty: bool,
 }
 
 impl<CS: CoordinateSystem> Island<CS> {
-  /// Creates a new island.
-  pub(crate) fn new() -> Self {
-    Self { nav_data: None, dirty: false }
+  /// Creates a new island. For details on the `type_index_to_node_type`
+  /// argument, see [`Self::set_type_index_to_node_type`].
+  pub fn new(
+    transform: Transform<CS>,
+    nav_mesh: Arc<ValidNavigationMesh<CS>>,
+    type_index_to_node_type: HashMap<usize, NodeType>,
+  ) -> Self {
+    Self {
+      transformed_bounds: nav_mesh.get_bounds().transform(&transform),
+      transform,
+      nav_mesh,
+      type_index_to_node_type,
+      dirty: true,
+    }
   }
 
   /// Gets the current transform of the island.
-  pub fn get_transform(&self) -> Option<&Transform<CS>> {
-    self.nav_data.as_ref().map(|d| &d.transform)
+  pub fn get_transform(&self) -> &Transform<CS> {
+    &self.transform
+  }
+
+  /// Sets the current transform of the island.
+  pub fn set_transform(&mut self, transform: Transform<CS>) {
+    self.transform = transform;
+    self.dirty = true;
+
+    self.transformed_bounds =
+      self.nav_mesh.get_bounds().transform(&self.transform);
   }
 
   /// Gets the current navigation mesh used by the island.
-  pub fn get_nav_mesh(&self) -> Option<Arc<ValidNavigationMesh<CS>>> {
-    self.nav_data.as_ref().map(|d| Arc::clone(&d.nav_mesh))
+  pub fn get_nav_mesh(&self) -> Arc<ValidNavigationMesh<CS>> {
+    self.nav_mesh.clone()
+  }
+
+  /// Sets the navigation mesh of the island.
+  pub fn set_nav_mesh(&mut self, nav_mesh: Arc<ValidNavigationMesh<CS>>) {
+    self.nav_mesh = nav_mesh;
+    self.dirty = true;
+
+    self.transformed_bounds =
+      self.nav_mesh.get_bounds().transform(&self.transform);
   }
 
   /// Gets the current `type_index_to_node_type` used by the island.
-  pub fn get_type_index_to_node_type(
-    &self,
-  ) -> Option<&HashMap<usize, NodeType>> {
-    self.nav_data.as_ref().map(|d| &d.type_index_to_node_type)
+  pub fn get_type_index_to_node_type(&self) -> &HashMap<usize, NodeType> {
+    &self.type_index_to_node_type
   }
 
-  /// Sets the navigation mesh and the transform of the island.
-  /// `type_index_to_node_type` translates the type indices used in `nav_mesh`
+  /// Sets the "translation" from the type indices used in the navigation mesh
   /// into [`NodeType`]s from the [`crate::Archipelago`]. Type indices without a
   /// corresponding node type will be treated as the "default" node type, which
   /// has a cost of 1.0. See [`crate::Archipelago::add_node_type`] for
   /// details on cost. [`NodeType`]s not present in the corresponding
   /// [`crate::Archipelago`] will cause a panic, so do not mix [`NodeType`]s
   /// across [`crate::Archipelago`]s.
-  pub fn set_nav_mesh(
+  pub fn set_type_index_to_node_type(
     &mut self,
-    transform: Transform<CS>,
-    nav_mesh: Arc<ValidNavigationMesh<CS>>,
     type_index_to_node_type: HashMap<usize, NodeType>,
   ) {
-    self.nav_data = Some(IslandNavigationData {
-      transformed_bounds: nav_mesh.get_bounds().transform(&transform),
-      transform,
-      nav_mesh,
-      type_index_to_node_type,
-    });
-    self.dirty = true;
-  }
-
-  /// Clears the navigation mesh from the island, making the island completely
-  /// empty.
-  pub fn clear_nav_mesh(&mut self) {
-    self.nav_data = None;
+    self.type_index_to_node_type = type_index_to_node_type;
     self.dirty = true;
   }
 }

--- a/crates/landmass/src/lib.rs
+++ b/crates/landmass/src/lib.rs
@@ -136,7 +136,7 @@ impl<CS: CoordinateSystem> Archipelago<CS> {
     self.characters.keys()
   }
 
-  pub fn add_island(&mut self, island: Island<CS>) -> IslandMut<'_, CS> {
+  pub fn add_island(&mut self, island: Island<CS>) -> IslandId {
     self.nav_data.add_island(island)
   }
 

--- a/crates/landmass/src/lib.rs
+++ b/crates/landmass/src/lib.rs
@@ -136,8 +136,8 @@ impl<CS: CoordinateSystem> Archipelago<CS> {
     self.characters.keys()
   }
 
-  pub fn add_island(&mut self) -> IslandMut<'_, CS> {
-    self.nav_data.add_island()
+  pub fn add_island(&mut self, island: Island<CS>) -> IslandMut<'_, CS> {
+    self.nav_data.add_island(island)
   }
 
   pub fn remove_island(&mut self, island_id: IslandId) {

--- a/crates/landmass/src/nav_data.rs
+++ b/crates/landmass/src/nav_data.rs
@@ -192,15 +192,10 @@ impl<CS: CoordinateSystem> NavigationData<CS> {
   }
 
   /// Adds a new island to the navigation data.
-  pub(crate) fn add_island(&mut self, island: Island<CS>) -> IslandMut<'_, CS> {
+  pub(crate) fn add_island(&mut self, island: Island<CS>) -> IslandId {
     // A new island means a new nav mesh - so mark it dirty.
     self.dirty = true;
-    let island_id = self.islands.insert(island);
-    IslandMut {
-      id: island_id,
-      island: self.islands.get_mut(island_id).unwrap(),
-      dirty_flag: &mut self.dirty,
-    }
+    self.islands.insert(island)
   }
 
   /// Gets a borrow to the island with `id`.

--- a/crates/landmass/src/nav_data.rs
+++ b/crates/landmass/src/nav_data.rs
@@ -2,7 +2,7 @@ use std::{
   collections::{HashMap, HashSet},
   mem::swap,
   ops::{Deref, DerefMut},
-  sync::{Arc, Mutex},
+  sync::Mutex,
 };
 
 use disjoint::DisjointSet;

--- a/crates/landmass/src/nav_data_test.rs
+++ b/crates/landmass/src/nav_data_test.rs
@@ -43,22 +43,16 @@ fn samples_points() {
   let nav_mesh = Arc::new(nav_mesh);
 
   let mut nav_data = NavigationData::<XYZ>::new();
-  let island_id_1 = nav_data
-    .add_island()
-    .set_nav_mesh(
-      Transform { translation: Vec3::ZERO, rotation: 0.0 },
-      Arc::clone(&nav_mesh),
-      HashMap::new(),
-    )
-    .id();
-  let island_id_2 = nav_data
-    .add_island()
-    .set_nav_mesh(
-      Transform { translation: Vec3::new(5.0, 0.0, 0.1), rotation: PI * 0.5 },
-      Arc::clone(&nav_mesh),
-      HashMap::new(),
-    )
-    .id();
+  let island_id_1 = nav_data.add_island(Island::new(
+    Transform { translation: Vec3::ZERO, rotation: 0.0 },
+    Arc::clone(&nav_mesh),
+    HashMap::new(),
+  ));
+  let island_id_2 = nav_data.add_island(Island::new(
+    Transform { translation: Vec3::new(5.0, 0.0, 0.1), rotation: PI * 0.5 },
+    Arc::clone(&nav_mesh),
+    HashMap::new(),
+  ));
 
   // Just above island 1 node.
   assert_eq!(
@@ -230,24 +224,22 @@ fn link_edges_between_islands_links_touching_islands() {
   let node_type_1 = slotmap.insert(0);
   let node_type_2 = slotmap.insert(0);
 
-  let mut island_1 = Island::new();
-  let mut island_2 = Island::new();
-
   let transform =
     Transform { translation: Vec3::new(1.0, 2.0, 3.0), rotation: PI * -0.25 };
-  island_1.set_nav_mesh(
+
+  let island_1 = Island::new(
     transform.clone(),
     Arc::clone(&nav_mesh_1),
     HashMap::from([(1, node_type_1)]),
   );
-  island_2.set_nav_mesh(
+  let island_2 = Island::new(
     transform.clone(),
     Arc::clone(&nav_mesh_2),
     HashMap::from([(1, node_type_2)]),
   );
 
-  let island_1_edge_bbh = island_edges_bbh(island_1.nav_data.as_ref().unwrap());
-  let island_2_edge_bbh = island_edges_bbh(island_2.nav_data.as_ref().unwrap());
+  let island_1_edge_bbh = island_edges_bbh(&island_1);
+  let island_2_edge_bbh = island_edges_bbh(&island_2);
 
   let mut boundary_links = SlotMap::with_key();
   let mut node_to_boundary_link_ids = HashMap::new();
@@ -530,46 +522,31 @@ fn update_links_islands_and_unlinks_on_delete() {
 
   let mut nav_data = NavigationData::<XYZ>::new();
 
-  let island_1_id = nav_data
-    .add_island()
-    .set_nav_mesh(
-      Transform { translation: Vec3::ZERO, rotation: 0.0 },
-      Arc::clone(&nav_mesh),
-      HashMap::new(),
-    )
-    .id();
-  let island_2_id = nav_data
-    .add_island()
-    .set_nav_mesh(
-      Transform { translation: Vec3::ZERO, rotation: PI * 0.5 },
-      Arc::clone(&nav_mesh),
-      HashMap::new(),
-    )
-    .id();
-  let island_3_id = nav_data
-    .add_island()
-    .set_nav_mesh(
-      Transform { translation: Vec3::ZERO, rotation: PI },
-      Arc::clone(&nav_mesh),
-      HashMap::new(),
-    )
-    .id();
-  let island_4_id = nav_data
-    .add_island()
-    .set_nav_mesh(
-      Transform { translation: Vec3::new(3.0, 0.0, 0.0), rotation: PI },
-      Arc::clone(&nav_mesh),
-      HashMap::new(),
-    )
-    .id();
-  let island_5_id = nav_data
-    .add_island()
-    .set_nav_mesh(
-      Transform { translation: Vec3::new(2.0, 3.0, 0.0), rotation: PI * -0.5 },
-      Arc::clone(&nav_mesh),
-      HashMap::new(),
-    )
-    .id();
+  let island_1_id = nav_data.add_island(Island::new(
+    Transform { translation: Vec3::ZERO, rotation: 0.0 },
+    Arc::clone(&nav_mesh),
+    HashMap::new(),
+  ));
+  let island_2_id = nav_data.add_island(Island::new(
+    Transform { translation: Vec3::ZERO, rotation: PI * 0.5 },
+    Arc::clone(&nav_mesh),
+    HashMap::new(),
+  ));
+  let island_3_id = nav_data.add_island(Island::new(
+    Transform { translation: Vec3::ZERO, rotation: PI },
+    Arc::clone(&nav_mesh),
+    HashMap::new(),
+  ));
+  let island_4_id = nav_data.add_island(Island::new(
+    Transform { translation: Vec3::new(3.0, 0.0, 0.0), rotation: PI },
+    Arc::clone(&nav_mesh),
+    HashMap::new(),
+  ));
+  let island_5_id = nav_data.add_island(Island::new(
+    Transform { translation: Vec3::new(2.0, 3.0, 0.0), rotation: PI * -0.5 },
+    Arc::clone(&nav_mesh),
+    HashMap::new(),
+  ));
 
   nav_data.update(/* edge_link_distance= */ 0.01);
 
@@ -696,11 +673,7 @@ fn update_links_islands_and_unlinks_on_delete() {
     .islands
     .get_mut(island_5_id)
     .expect("island_5 still exists")
-    .set_nav_mesh(
-      Transform { translation: Vec3::ZERO, rotation: PI * 0.5 },
-      Arc::clone(&nav_mesh),
-      HashMap::new(),
-    );
+    .set_transform(Transform { translation: Vec3::ZERO, rotation: PI * 0.5 });
 
   nav_data.update(/* edge_link_distance= */ 0.01);
 
@@ -853,30 +826,21 @@ fn modifies_node_boundaries_for_linked_islands() {
 
   let mut nav_data = NavigationData::<XYZ>::new();
 
-  let island_1_id = nav_data
-    .add_island()
-    .set_nav_mesh(
-      Transform { translation: Vec3::ZERO, rotation: 0.0 },
-      Arc::clone(&nav_mesh),
-      HashMap::new(),
-    )
-    .id();
-  let island_2_id = nav_data
-    .add_island()
-    .set_nav_mesh(
-      Transform { translation: Vec3::new(1.0, -1.0, 0.0), rotation: 0.0 },
-      Arc::clone(&nav_mesh),
-      HashMap::new(),
-    )
-    .id();
-  let island_3_id = nav_data
-    .add_island()
-    .set_nav_mesh(
-      Transform { translation: Vec3::new(2.0, 3.5, 0.0), rotation: PI * -0.5 },
-      Arc::clone(&nav_mesh),
-      HashMap::new(),
-    )
-    .id();
+  let island_1_id = nav_data.add_island(Island::new(
+    Transform { translation: Vec3::ZERO, rotation: 0.0 },
+    Arc::clone(&nav_mesh),
+    HashMap::new(),
+  ));
+  let island_2_id = nav_data.add_island(Island::new(
+    Transform { translation: Vec3::new(1.0, -1.0, 0.0), rotation: 0.0 },
+    Arc::clone(&nav_mesh),
+    HashMap::new(),
+  ));
+  let island_3_id = nav_data.add_island(Island::new(
+    Transform { translation: Vec3::new(2.0, 3.5, 0.0), rotation: PI * -0.5 },
+    Arc::clone(&nav_mesh),
+    HashMap::new(),
+  ));
 
   nav_data.update(/* edge_link_distance= */ 1e-6);
 
@@ -933,19 +897,16 @@ fn stale_modified_nodes_are_removed() {
 
   let mut nav_data = NavigationData::<XYZ>::new();
 
-  nav_data.add_island().set_nav_mesh(
+  nav_data.add_island(Island::new(
     Transform { translation: Vec3::ZERO, rotation: 0.0 },
     Arc::clone(&nav_mesh),
     HashMap::new(),
-  );
-  let island_2_id = nav_data
-    .add_island()
-    .set_nav_mesh(
-      Transform { translation: Vec3::new(1.0, -1.0, 0.0), rotation: 0.0 },
-      Arc::clone(&nav_mesh),
-      HashMap::new(),
-    )
-    .id();
+  ));
+  let island_2_id = nav_data.add_island(Island::new(
+    Transform { translation: Vec3::new(1.0, -1.0, 0.0), rotation: 0.0 },
+    Arc::clone(&nav_mesh),
+    HashMap::new(),
+  ));
 
   nav_data.update(/* edge_link_distance= */ 1e-6);
 
@@ -986,16 +947,16 @@ fn empty_navigation_mesh_is_safe() {
   );
 
   let mut nav_data = NavigationData::<XYZ>::new();
-  nav_data.add_island().set_nav_mesh(
+  nav_data.add_island(Island::new(
     Transform::default(),
     full_nav_mesh,
     HashMap::new(),
-  );
-  nav_data.add_island().set_nav_mesh(
+  ));
+  nav_data.add_island(Island::new(
     Transform::default(),
     empty_nav_mesh,
     HashMap::new(),
-  );
+  ));
 
   // Nothing should panic here.
   nav_data.update(/* edge_link_distance= */ 1e-6);
@@ -1052,30 +1013,24 @@ fn cannot_remove_used_node_type() {
     .expect("mesh is valid"),
   );
 
-  let island_id_1 = archipelago
-    .add_island()
-    .set_nav_mesh(
-      Transform::default(),
-      nav_mesh.clone(),
-      HashMap::from([(0, node_type_1)]),
-    )
-    .id();
+  let island_id_1 = archipelago.add_island(Island::new(
+    Transform::default(),
+    nav_mesh.clone(),
+    HashMap::from([(0, node_type_1)]),
+  ));
 
-  let island_id_2 = archipelago
-    .add_island()
-    .set_nav_mesh(
-      Transform::default(),
-      nav_mesh.clone(),
-      HashMap::from([(0, node_type_1)]),
-    )
-    .id();
+  let island_id_2 = archipelago.add_island(Island::new(
+    Transform::default(),
+    nav_mesh.clone(),
+    HashMap::from([(0, node_type_1)]),
+  ));
 
   // Another island that has no effect since it doesn't mention `node_type_1`.
-  archipelago.add_island().set_nav_mesh(
+  archipelago.add_island(Island::new(
     Transform::default(),
     nav_mesh.clone(),
     HashMap::from([(0, node_type_2)]),
-  );
+  ));
 
   assert_eq!(
     archipelago.nav_data.get_node_types().collect::<Vec<_>>(),
@@ -1132,11 +1087,11 @@ fn panics_on_invalid_node_type() {
     .expect("mesh is valid"),
   );
 
-  archipelago.add_island().set_nav_mesh(
+  archipelago.add_island(Island::new(
     Transform::default(),
     nav_mesh,
     HashMap::from([(0, deleted_node_type)]),
-  );
+  ));
 
   // Panics due to referencing invalid node type.
   archipelago.update(1.0);

--- a/crates/landmass/src/path.rs
+++ b/crates/landmass/src/path.rs
@@ -54,9 +54,6 @@ impl IslandSegment {
 
     let island_data = nav_data
       .get_island(self.island_id)
-      .expect("only called if path is still valid")
-      .nav_data
-      .as_ref()
       .expect("only called if path is still valid");
     let (left_vertex, right_vertex) =
       island_data.nav_mesh.polygons[polygon_index].get_edge_indices(edge);

--- a/crates/landmass/src/path_test.rs
+++ b/crates/landmass/src/path_test.rs
@@ -12,7 +12,7 @@ use crate::{
   nav_data::{BoundaryLinkId, NavigationData, NodeRef},
   nav_mesh::NavigationMesh,
   path::{BoundaryLinkSegment, IslandSegment},
-  Archipelago, CoordinateSystem, IslandId, Transform,
+  Archipelago, CoordinateSystem, Island, IslandId, Transform,
 };
 
 use super::{Path, PathIndex};
@@ -73,10 +73,11 @@ fn finds_next_point_for_organic_map() {
   let transform =
     Transform { translation: Vec3::new(5.0, 9.0, 7.0), rotation: PI * -0.35 };
   let mut archipelago = Archipelago::<XYZ>::new();
-  let island_id = archipelago
-    .add_island()
-    .set_nav_mesh(transform.clone(), Arc::new(nav_mesh), HashMap::new())
-    .id();
+  let island_id = archipelago.add_island(Island::new(
+    transform.clone(),
+    Arc::new(nav_mesh),
+    HashMap::new(),
+  ));
 
   let path = Path {
     island_segments: vec![IslandSegment {
@@ -178,10 +179,11 @@ fn finds_next_point_in_zig_zag() {
   let transform =
     Transform { translation: Vec2::new(-1.0, -3.0), rotation: PI * -1.8 };
   let mut archipelago = Archipelago::<XY>::new();
-  let island_id = archipelago
-    .add_island()
-    .set_nav_mesh(transform.clone(), Arc::new(nav_mesh), HashMap::new())
-    .id();
+  let island_id = archipelago.add_island(Island::new(
+    transform.clone(),
+    Arc::new(nav_mesh),
+    HashMap::new(),
+  ));
 
   let path = Path {
     island_segments: vec![IslandSegment {
@@ -251,14 +253,11 @@ fn starts_at_end_index_goes_to_end_point() {
   .expect("Mesh is valid.");
 
   let mut archipelago = Archipelago::<XYZ>::new();
-  let island_id = archipelago
-    .add_island()
-    .set_nav_mesh(
-      Transform { translation: Vec3::ZERO, rotation: 0.0 },
-      Arc::new(nav_mesh),
-      HashMap::new(),
-    )
-    .id();
+  let island_id = archipelago.add_island(Island::new(
+    Transform { translation: Vec3::ZERO, rotation: 0.0 },
+    Arc::new(nav_mesh),
+    HashMap::new(),
+  ));
 
   let path = Path {
     island_segments: vec![IslandSegment {

--- a/crates/landmass/src/pathfinding_test.rs
+++ b/crates/landmass/src/pathfinding_test.rs
@@ -7,7 +7,7 @@ use crate::{
   nav_data::NodeRef,
   nav_mesh::NavigationMesh,
   path::{BoundaryLinkSegment, IslandSegment, Path},
-  Archipelago, Transform,
+  Archipelago, Island, Transform,
 };
 
 use super::find_path;
@@ -44,14 +44,11 @@ fn finds_path_in_archipelago() {
   .expect("Mesh is valid.");
 
   let mut archipelago = Archipelago::<XYZ>::new();
-  let island_id = archipelago
-    .add_island()
-    .set_nav_mesh(
-      Transform { translation: Vec3::ZERO, rotation: 0.0 },
-      Arc::new(nav_mesh),
-      HashMap::new(),
-    )
-    .id();
+  let island_id = archipelago.add_island(Island::new(
+    Transform { translation: Vec3::ZERO, rotation: 0.0 },
+    Arc::new(nav_mesh),
+    HashMap::new(),
+  ));
 
   let nav_data = &archipelago.nav_data;
 
@@ -146,23 +143,17 @@ fn finds_paths_on_two_islands() {
   let nav_mesh = Arc::new(nav_mesh);
 
   let mut archipelago = Archipelago::<XYZ>::new();
-  let island_id_1 = archipelago
-    .add_island()
-    .set_nav_mesh(
-      Transform { translation: Vec3::ZERO, rotation: 0.0 },
-      Arc::clone(&nav_mesh),
-      HashMap::new(),
-    )
-    .id();
+  let island_id_1 = archipelago.add_island(Island::new(
+    Transform { translation: Vec3::ZERO, rotation: 0.0 },
+    Arc::clone(&nav_mesh),
+    HashMap::new(),
+  ));
 
-  let island_id_2 = archipelago
-    .add_island()
-    .set_nav_mesh(
-      Transform { translation: Vec3::new(6.0, 0.0, 0.0), rotation: PI * -0.5 },
-      Arc::clone(&nav_mesh),
-      HashMap::new(),
-    )
-    .id();
+  let island_id_2 = archipelago.add_island(Island::new(
+    Transform { translation: Vec3::new(6.0, 0.0, 0.0), rotation: PI * -0.5 },
+    Arc::clone(&nav_mesh),
+    HashMap::new(),
+  ));
 
   let nav_data = &archipelago.nav_data;
 
@@ -238,23 +229,17 @@ fn no_path_between_disconnected_islands() {
   let nav_mesh = Arc::new(nav_mesh);
 
   let mut archipelago = Archipelago::<XYZ>::new();
-  let island_id_1 = archipelago
-    .add_island()
-    .set_nav_mesh(
-      Transform { translation: Vec3::ZERO, rotation: 0.0 },
-      Arc::clone(&nav_mesh),
-      HashMap::new(),
-    )
-    .id();
+  let island_id_1 = archipelago.add_island(Island::new(
+    Transform { translation: Vec3::ZERO, rotation: 0.0 },
+    Arc::clone(&nav_mesh),
+    HashMap::new(),
+  ));
 
-  let island_id_2 = archipelago
-    .add_island()
-    .set_nav_mesh(
-      Transform { translation: Vec3::new(6.0, 0.0, 0.0), rotation: PI * -0.5 },
-      Arc::clone(&nav_mesh),
-      HashMap::new(),
-    )
-    .id();
+  let island_id_2 = archipelago.add_island(Island::new(
+    Transform { translation: Vec3::new(6.0, 0.0, 0.0), rotation: PI * -0.5 },
+    Arc::clone(&nav_mesh),
+    HashMap::new(),
+  ));
 
   let nav_data = &archipelago.nav_data;
 
@@ -296,44 +281,32 @@ fn find_path_across_connected_islands() {
 
   let mut archipelago = Archipelago::<XYZ>::new();
 
-  let island_id_1 = archipelago
-    .add_island()
-    .set_nav_mesh(
-      Transform { rotation: 0.0, translation: Vec3::ZERO },
-      Arc::clone(&nav_mesh),
-      HashMap::new(),
-    )
-    .id();
-  let island_id_2 = archipelago
-    .add_island()
-    .set_nav_mesh(
-      Transform { rotation: 0.0, translation: Vec3::new(1.0, 0.0, 0.0) },
-      Arc::clone(&nav_mesh),
-      HashMap::new(),
-    )
-    .id();
+  let island_id_1 = archipelago.add_island(Island::new(
+    Transform { rotation: 0.0, translation: Vec3::ZERO },
+    Arc::clone(&nav_mesh),
+    HashMap::new(),
+  ));
+  let island_id_2 = archipelago.add_island(Island::new(
+    Transform { rotation: 0.0, translation: Vec3::new(1.0, 0.0, 0.0) },
+    Arc::clone(&nav_mesh),
+    HashMap::new(),
+  ));
   // island_id_3 is unused.
-  archipelago.add_island().set_nav_mesh(
+  archipelago.add_island(Island::new(
     Transform { rotation: 0.0, translation: Vec3::new(1.0, -1.0, 0.0) },
     Arc::clone(&nav_mesh),
     HashMap::new(),
-  );
-  let island_id_4 = archipelago
-    .add_island()
-    .set_nav_mesh(
-      Transform { rotation: 0.0, translation: Vec3::new(1.0, 1.0, 0.0) },
-      Arc::clone(&nav_mesh),
-      HashMap::new(),
-    )
-    .id();
-  let island_id_5 = archipelago
-    .add_island()
-    .set_nav_mesh(
-      Transform { rotation: 0.0, translation: Vec3::new(1.0, 2.0, 0.0) },
-      Arc::clone(&nav_mesh),
-      HashMap::new(),
-    )
-    .id();
+  ));
+  let island_id_4 = archipelago.add_island(Island::new(
+    Transform { rotation: 0.0, translation: Vec3::new(1.0, 1.0, 0.0) },
+    Arc::clone(&nav_mesh),
+    HashMap::new(),
+  ));
+  let island_id_5 = archipelago.add_island(Island::new(
+    Transform { rotation: 0.0, translation: Vec3::new(1.0, 2.0, 0.0) },
+    Arc::clone(&nav_mesh),
+    HashMap::new(),
+  ));
 
   archipelago.update(1.0);
 
@@ -434,22 +407,16 @@ fn finds_path_across_different_islands() {
 
   let mut archipelago = Archipelago::<XYZ>::new();
 
-  let island_id_1 = archipelago
-    .add_island()
-    .set_nav_mesh(
-      Transform { rotation: 0.0, translation: Vec3::ZERO },
-      nav_mesh_1,
-      HashMap::new(),
-    )
-    .id();
-  let island_id_2 = archipelago
-    .add_island()
-    .set_nav_mesh(
-      Transform { rotation: 0.0, translation: Vec3::new(1.0, 0.0, 0.0) },
-      nav_mesh_2,
-      HashMap::new(),
-    )
-    .id();
+  let island_id_1 = archipelago.add_island(Island::new(
+    Transform { rotation: 0.0, translation: Vec3::ZERO },
+    nav_mesh_1,
+    HashMap::new(),
+  ));
+  let island_id_2 = archipelago.add_island(Island::new(
+    Transform { rotation: 0.0, translation: Vec3::new(1.0, 0.0, 0.0) },
+    nav_mesh_2,
+    HashMap::new(),
+  ));
 
   archipelago.update(1.0);
 
@@ -514,30 +481,21 @@ fn aborts_early_for_unconnected_regions() {
 
   let mut archipelago = Archipelago::<XYZ>::new();
 
-  let island_id_1 = archipelago
-    .add_island()
-    .set_nav_mesh(
-      Transform { translation: Vec3::ZERO, rotation: 0.0 },
-      nav_mesh.clone(),
-      HashMap::new(),
-    )
-    .id();
-  let island_id_2 = archipelago
-    .add_island()
-    .set_nav_mesh(
-      Transform { translation: Vec3::new(2.0, 0.0, 0.0), rotation: 0.0 },
-      nav_mesh.clone(),
-      HashMap::new(),
-    )
-    .id();
-  let island_id_3 = archipelago
-    .add_island()
-    .set_nav_mesh(
-      Transform { translation: Vec3::new(1.5, 2.0, 0.0), rotation: PI * 0.5 },
-      nav_mesh.clone(),
-      HashMap::new(),
-    )
-    .id();
+  let island_id_1 = archipelago.add_island(Island::new(
+    Transform { translation: Vec3::ZERO, rotation: 0.0 },
+    nav_mesh.clone(),
+    HashMap::new(),
+  ));
+  let island_id_2 = archipelago.add_island(Island::new(
+    Transform { translation: Vec3::new(2.0, 0.0, 0.0), rotation: 0.0 },
+    nav_mesh.clone(),
+    HashMap::new(),
+  ));
+  let island_id_3 = archipelago.add_island(Island::new(
+    Transform { translation: Vec3::new(1.5, 2.0, 0.0), rotation: PI * 0.5 },
+    nav_mesh.clone(),
+    HashMap::new(),
+  ));
 
   archipelago.update(1.0);
 
@@ -619,14 +577,11 @@ fn detour_for_high_cost_path() {
 
   let slow_node_type = archipelago.add_node_type(10.0).unwrap();
 
-  let island_id = archipelago
-    .add_island()
-    .set_nav_mesh(
-      Transform::default(),
-      nav_mesh,
-      HashMap::from([(1, slow_node_type)]),
-    )
-    .id();
+  let island_id = archipelago.add_island(Island::new(
+    Transform::default(),
+    nav_mesh,
+    HashMap::from([(1, slow_node_type)]),
+  ));
 
   let path_result = find_path(
     &archipelago.nav_data,
@@ -708,18 +663,16 @@ fn detour_for_high_cost_path_across_boundary_links() {
 
   let slow_node_type = archipelago.add_node_type(5.1).unwrap();
 
-  let island_id_1 = archipelago
-    .add_island()
-    .set_nav_mesh(Transform::default(), nav_mesh_1, HashMap::new())
-    .id();
-  let island_id_2 = archipelago
-    .add_island()
-    .set_nav_mesh(
-      Transform::default(),
-      nav_mesh_2,
-      HashMap::from([(1, slow_node_type)]),
-    )
-    .id();
+  let island_id_1 = archipelago.add_island(Island::new(
+    Transform::default(),
+    nav_mesh_1,
+    HashMap::new(),
+  ));
+  let island_id_2 = archipelago.add_island(Island::new(
+    Transform::default(),
+    nav_mesh_2,
+    HashMap::from([(1, slow_node_type)]),
+  ));
 
   archipelago.update(1.0);
 
@@ -811,14 +764,11 @@ fn fast_path_not_ignored_by_heuristic() {
   // This node type is faster than default.
   let fast_type = archipelago.add_node_type(0.5).unwrap();
 
-  let island_id = archipelago
-    .add_island()
-    .set_nav_mesh(
-      Transform::default(),
-      nav_mesh,
-      HashMap::from([(1, fast_type)]),
-    )
-    .id();
+  let island_id = archipelago.add_island(Island::new(
+    Transform::default(),
+    nav_mesh,
+    HashMap::from([(1, fast_type)]),
+  ));
 
   let path_result = find_path(
     &archipelago.nav_data,
@@ -866,14 +816,11 @@ fn infinite_or_nan_cost_cannot_find_path() {
 
   let node_type = archipelago.add_node_type(f32::INFINITY).unwrap();
 
-  let island_id = archipelago
-    .add_island()
-    .set_nav_mesh(
-      Transform::default(),
-      nav_mesh,
-      HashMap::from([(1, node_type)]),
-    )
-    .id();
+  let island_id = archipelago.add_island(Island::new(
+    Transform::default(),
+    nav_mesh,
+    HashMap::from([(1, node_type)]),
+  ));
 
   let path_result = find_path(
     &archipelago.nav_data,
@@ -950,14 +897,11 @@ fn detour_for_overridden_high_cost_path() {
 
   let slow_node_type = archipelago.add_node_type(1.0).unwrap();
 
-  let island_id = archipelago
-    .add_island()
-    .set_nav_mesh(
-      Transform::default(),
-      nav_mesh,
-      HashMap::from([(1, slow_node_type)]),
-    )
-    .id();
+  let island_id = archipelago.add_island(Island::new(
+    Transform::default(),
+    nav_mesh,
+    HashMap::from([(1, slow_node_type)]),
+  ));
 
   let path_result = find_path(
     &archipelago.nav_data,

--- a/crates/landmass/src/query_test.rs
+++ b/crates/landmass/src/query_test.rs
@@ -3,8 +3,8 @@ use std::{collections::HashMap, sync::Arc};
 use glam::Vec2;
 
 use crate::{
-  coords::XY, Archipelago, FindPathError, NavigationMesh, SamplePointError,
-  Transform,
+  coords::XY, Archipelago, FindPathError, Island, NavigationMesh,
+  SamplePointError, Transform,
 };
 
 use super::{find_path, sample_point};
@@ -28,11 +28,11 @@ fn error_on_dirty_nav_mesh() {
     .expect("nav mesh is valid"),
   );
 
-  archipelago.add_island().set_nav_mesh(
+  archipelago.add_island(Island::new(
     Transform::default(),
     nav_mesh,
     HashMap::new(),
-  );
+  ));
   assert_eq!(
     sample_point(
       &archipelago,
@@ -63,11 +63,11 @@ fn error_on_out_of_range() {
     .expect("nav mesh is valid"),
   );
 
-  archipelago.add_island().set_nav_mesh(
+  archipelago.add_island(Island::new(
     Transform::default(),
     nav_mesh,
     HashMap::new(),
-  );
+  ));
   archipelago.update(1.0);
 
   assert_eq!(
@@ -101,11 +101,11 @@ fn samples_point_on_nav_mesh_or_near_nav_mesh() {
   );
 
   let offset = Vec2::new(10.0, 10.0);
-  archipelago.add_island().set_nav_mesh(
+  archipelago.add_island(Island::new(
     Transform { translation: offset, rotation: 0.0 },
     nav_mesh,
     HashMap::new(),
-  );
+  ));
   archipelago.update(1.0);
 
   assert_eq!(
@@ -157,16 +157,16 @@ fn no_path() {
   );
 
   let offset = Vec2::new(10.0, 10.0);
-  archipelago.add_island().set_nav_mesh(
+  archipelago.add_island(Island::new(
     Transform { translation: offset, rotation: 0.0 },
     nav_mesh.clone(),
     HashMap::new(),
-  );
-  archipelago.add_island().set_nav_mesh(
+  ));
+  archipelago.add_island(Island::new(
     Transform { translation: offset + Vec2::new(2.0, 0.0), rotation: 0.0 },
     nav_mesh,
     HashMap::new(),
-  );
+  ));
   archipelago.update(1.0);
 
   let start_point = archipelago
@@ -201,21 +201,21 @@ fn finds_path() {
   );
 
   let offset = Vec2::new(10.0, 10.0);
-  archipelago.add_island().set_nav_mesh(
+  archipelago.add_island(Island::new(
     Transform { translation: offset, rotation: 0.0 },
     nav_mesh.clone(),
     HashMap::new(),
-  );
-  archipelago.add_island().set_nav_mesh(
+  ));
+  archipelago.add_island(Island::new(
     Transform { translation: offset + Vec2::new(1.0, 0.0), rotation: 0.0 },
     nav_mesh.clone(),
     HashMap::new(),
-  );
-  archipelago.add_island().set_nav_mesh(
+  ));
+  archipelago.add_island(Island::new(
     Transform { translation: offset + Vec2::new(2.0, 0.5), rotation: 0.0 },
     nav_mesh,
     HashMap::new(),
-  );
+  ));
   archipelago.update(1.0);
 
   let start_point = archipelago
@@ -285,11 +285,11 @@ fn finds_path_with_override_node_types() {
 
   let node_type = archipelago.add_node_type(1.0).unwrap();
 
-  archipelago.add_island().set_nav_mesh(
+  archipelago.add_island(Island::new(
     Transform::default(),
     nav_mesh,
     HashMap::from([(1, node_type)]),
-  );
+  ));
 
   archipelago.update(1.0);
 
@@ -346,11 +346,11 @@ fn find_path_returns_error_on_invalid_node_cost() {
 
   let node_type = archipelago.add_node_type(1.0).unwrap();
 
-  archipelago.add_island().set_nav_mesh(
+  archipelago.add_island(Island::new(
     Transform::default(),
     nav_mesh,
     HashMap::from([(0, node_type)]),
-  );
+  ));
 
   archipelago.update(1.0);
 


### PR DESCRIPTION
Fixes #72.

Now clearing a nav mesh is just removing a nav mesh! We use to have empty islands a long time ago to support a "region" of interest for each island. Now islands don't have this so we can just make them live wherever the nav mesh is.