### PR TITLE
Improve the bevy_landmass example to include an example of a "slow path".

### DIFF
--- a/crates/bevy_landmass/example/main.rs
+++ b/crates/bevy_landmass/example/main.rs
@@ -98,7 +98,7 @@ fn setup(
 
   commands.spawn(TextBundle {
     text: Text::from_section(
-      "LMB - Spawn agent\nShift+LMB - Spawn agent (fast on mud)\nRMB - Change target point",
+      "LMB - Spawn agent\nShift+LMB - Spawn agent (fast on mud)\nRMB - Change target point\nF12 - Toggle debug view",
       TextStyle::default()
     ).with_justify(JustifyText::Right),
     style: Style {

--- a/crates/bevy_landmass/example/main.rs
+++ b/crates/bevy_landmass/example/main.rs
@@ -96,6 +96,20 @@ fn setup(
     ..Default::default()
   });
 
+  commands.spawn(TextBundle {
+    text: Text::from_section(
+      "LMB - Spawn agent\nShift+LMB - Spawn agent (fast on mud)\nRMB - Change target point",
+      TextStyle::default()
+    ).with_justify(JustifyText::Right),
+    style: Style {
+      position_type: PositionType::Absolute,
+      right: Val::Px(0.0),
+      bottom: Val::Px(0.0),
+      ..Default::default()
+    },
+    ..Default::default()
+  });
+
   let slow_area = Rect::from_corners(
     Vec2::new(-3.99582, -2.89418),
     Vec2::new(3.30418, 4.00582),


### PR DESCRIPTION
Now the center of one of the nav meshes is a slow path, and we can spawn agents that can take the fast path.

I also added a message to explain the keybinds.