### PR TITLE
Bump landmass_oxidized_navigation to 0.2.0-dev.

### DIFF
--- a/crates/landmass_oxidized_navigation/Cargo.toml
+++ b/crates/landmass_oxidized_navigation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "landmass_oxidized_navigation"
-version = "0.1.0"
+version = "0.2.0-dev"
 edition = "2021"
 
 description = "An integration between bevy_landmass and oxidized_navigation for AI navigation."


### PR DESCRIPTION
This matches the other crates in this repo!