### PR TITLE
Fix the dependency on bevy_landmass to use 0.8.0-dev for landmass_oxidized_navigation.

### DIFF
--- a/crates/landmass_oxidized_navigation/Cargo.toml
+++ b/crates/landmass_oxidized_navigation/Cargo.toml
@@ -22,7 +22,7 @@ type_complexity = "allow"
 bevy = { version = "0.14.0", default-features = false, features = [
   "bevy_asset",
 ] }
-bevy_landmass = { version = "0.7.0" }
+bevy_landmass = { path = "../bevy_landmass", version = "0.8.0-dev" }
 oxidized_navigation = "0.11.0"
 
 [dev-dependencies]


### PR DESCRIPTION
I forgot to update this dependency when I bumped the version to 0.2.0-dev.