### PR TITLE
Upgrade Bevy to 0.15.0-rc.2.

### DIFF
--- a/crates/bevy_landmass/Cargo.toml
+++ b/crates/bevy_landmass/Cargo.toml
@@ -19,14 +19,14 @@ exclude = ["/assets"]
 type_complexity = "allow"
 
 [dependencies]
-bevy = { version = "0.14.0", default-features = false, features = [
+bevy = { version = "0.15.0-rc.2", default-features = false, features = [
   "bevy_asset",
   "bevy_gizmos",
 ] }
 landmass = { path = "../landmass", version = "0.7.0-dev" }
 
 [dev-dependencies]
-bevy = "0.14.0"
+bevy = "0.15.0-rc.2"
 
 [features]
 default = ["mesh-utils"]

--- a/crates/bevy_landmass/README.md
+++ b/crates/bevy_landmass/README.md
@@ -86,7 +86,7 @@ fn set_up_scene(
   commands.spawn((
     Transform::from_translation(Vec3::new(1.5, 1.5, 0.0)),
     Agent2dBundle {
-      agent: Agent {
+      settings: AgentSettings {
         radius: 0.5,
         desired_speed: 1.0,
         max_speed: 2.0,

--- a/crates/bevy_landmass/README.md
+++ b/crates/bevy_landmass/README.md
@@ -86,17 +86,15 @@ fn set_up_scene(
   commands.spawn((
     Transform::from_translation(Vec3::new(1.5, 1.5, 0.0)),
     Agent2dBundle {
+      agent: Default::default(),
       settings: AgentSettings {
         radius: 0.5,
         desired_speed: 1.0,
         max_speed: 2.0,
       },
       archipelago_ref: ArchipelagoRef2d::new(archipelago_id),
-      target: AgentTarget2d::Point(Vec2::new(1.5, 3.5)),
-      velocity: Default::default(),
-      state: Default::default(),
-      desired_velocity: Default::default(),
-    }
+    },
+    AgentTarget2d::Point(Vec2::new(1.5, 3.5)),
   ));
 }
 

--- a/crates/bevy_landmass/README.md
+++ b/crates/bevy_landmass/README.md
@@ -27,7 +27,7 @@ have an `ArchipelagoRef` to it. Agents/islands will be added once the
 use std::sync::Arc;
 
 use bevy::{app::AppExit, prelude::*};
-use bevy_landmass::prelude::*;
+use bevy_landmass::{prelude::*, NavMeshHandle};
 
 fn main() {
   App::new()
@@ -51,11 +51,10 @@ fn set_up_scene(
 
   commands
     .spawn((
-      TransformBundle::default(),
       Island2dBundle {
         island: Island,
         archipelago_ref: ArchipelagoRef2d::new(archipelago_id),
-        nav_mesh: nav_mesh_handle.clone(),
+        nav_mesh: NavMeshHandle(nav_mesh_handle.clone()),
       },
     ));
   
@@ -85,10 +84,7 @@ fn set_up_scene(
   });
 
   commands.spawn((
-    TransformBundle {
-      local: Transform::from_translation(Vec3::new(1.5, 1.5, 0.0)),
-      ..Default::default()
-    },
+    Transform::from_translation(Vec3::new(1.5, 1.5, 0.0)),
     Agent2dBundle {
       agent: Agent {
         radius: 0.5,

--- a/crates/bevy_landmass/example/main.rs
+++ b/crates/bevy_landmass/example/main.rs
@@ -215,17 +215,15 @@ impl AgentSpawner {
         Mesh2d(self.mesh.clone()),
         MeshMaterial2d(self.material.clone()),
         Agent2dBundle {
+          agent: Default::default(),
           settings: AgentSettings {
             radius: 0.5,
             desired_speed: 2.0,
             max_speed: 3.0,
           },
           archipelago_ref: ArchipelagoRef2d::new(self.archipelago_entity),
-          target: AgentTarget2d::Entity(self.target_entity),
-          state: Default::default(),
-          velocity: Default::default(),
-          desired_velocity: Default::default(),
         },
+        AgentTarget2d::Entity(self.target_entity),
       ))
       .id();
 

--- a/crates/bevy_landmass/example/main.rs
+++ b/crates/bevy_landmass/example/main.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use bevy::{
   color::palettes::css, input::common_conditions::input_just_pressed,
-  prelude::*, render::mesh::Mesh2d, sprite::MaterialMesh2dBundle,
+  prelude::*, render::mesh::Mesh2d,
 };
 use bevy_landmass::{
   debug::{EnableLandmassDebug, Landmass2dDebugPlugin},
@@ -84,16 +84,16 @@ fn setup(
   nav_meshes: Res<Assets<NavMesh2d>>,
   asset_server: Res<AssetServer>,
 ) {
-  commands.spawn(Camera2dBundle {
-    transform: Transform::from_xyz(5.0, 0.0, 0.0),
-    projection: OrthographicProjection {
+  commands.spawn((
+    Transform::from_xyz(5.0, 0.0, 0.0),
+    Camera2d,
+    OrthographicProjection {
       scaling_mode: bevy::render::camera::ScalingMode::FixedVertical {
         viewport_height: 16.0,
       },
       ..OrthographicProjection::default_2d()
     },
-    ..Default::default()
-  });
+  ));
 
   let message = "LMB - Spawn agent\nShift+LMB - Spawn agent (fast on mud)\nRMB - Change target point\nF12 - Toggle debug view";
   commands.spawn((
@@ -111,15 +111,14 @@ fn setup(
     Vec2::new(-3.99582, -2.89418),
     Vec2::new(3.30418, 4.00582),
   );
-  commands.spawn(MaterialMesh2dBundle {
-    transform: Transform::from_translation(slow_area.center().extend(1.0)),
-    mesh: Mesh2d(meshes.add(Rectangle { half_size: slow_area.size() * 0.5 })),
-    material: MeshMaterial2d(materials.add(ColorMaterial {
+  commands.spawn((
+    Transform::from_translation(slow_area.center().extend(1.0)),
+    Mesh2d(meshes.add(Rectangle { half_size: slow_area.size() * 0.5 })),
+    MeshMaterial2d(materials.add(ColorMaterial {
       color: css::BROWN.with_alpha(0.5).into(),
       ..Default::default()
     })),
-    ..Default::default()
-  });
+  ));
 
   let mut archipelago = Archipelago2d::new();
   let slow_node_type = archipelago.add_node_type(1000.0).unwrap();
@@ -129,14 +128,11 @@ fn setup(
   let mesh_1: Handle<Mesh> = asset_server.load("nav_mesh.glb#Mesh0/Primitive0");
   let nav_mesh_1 = nav_meshes.reserve_handle();
   commands.spawn((
-    MaterialMesh2dBundle {
-      mesh: Mesh2d(mesh_1.clone()),
-      material: MeshMaterial2d(materials.add(ColorMaterial {
-        color: css::ANTIQUE_WHITE.into(),
-        ..Default::default()
-      })),
+    Mesh2d(mesh_1.clone()),
+    MeshMaterial2d(materials.add(ColorMaterial {
+      color: css::ANTIQUE_WHITE.into(),
       ..Default::default()
-    },
+    })),
     Island2dBundle {
       archipelago_ref: ArchipelagoRef2d::new(archipelago_entity),
       island: Island,
@@ -153,15 +149,12 @@ fn setup(
   let mesh_2: Handle<Mesh> = asset_server.load("nav_mesh.glb#Mesh1/Primitive0");
   let nav_mesh_2 = nav_meshes.reserve_handle();
   commands.spawn((
-    MaterialMesh2dBundle {
-      mesh: Mesh2d(mesh_2.clone()),
-      material: MeshMaterial2d(materials.add(ColorMaterial {
-        color: css::ANTIQUE_WHITE.into(),
-        ..Default::default()
-      })),
-      transform: Transform::from_translation(Vec3::new(12.0, 0.0, 0.0)),
+    Mesh2d(mesh_2.clone()),
+    MeshMaterial2d(materials.add(ColorMaterial {
+      color: css::ANTIQUE_WHITE.into(),
       ..Default::default()
-    },
+    })),
+    Transform::from_translation(Vec3::new(12.0, 0.0, 0.0)),
     Island2dBundle {
       archipelago_ref: ArchipelagoRef2d::new(archipelago_entity),
       island: Island,
@@ -178,15 +171,12 @@ fn setup(
   // Spawn the target.
   let target_entity = commands
     .spawn((
-      MaterialMesh2dBundle {
-        transform: Transform::from_translation(Vec3::new(0.0, 6.0, 0.11)),
-        mesh: Mesh2d(meshes.add(Circle { radius: 0.25 })),
-        material: MeshMaterial2d(materials.add(ColorMaterial {
-          color: css::PURPLE.into(),
-          ..Default::default()
-        })),
+      Transform::from_translation(Vec3::new(0.0, 6.0, 0.11)),
+      Mesh2d(meshes.add(Circle { radius: 0.25 })),
+      MeshMaterial2d(materials.add(ColorMaterial {
+        color: css::PURPLE.into(),
         ..Default::default()
-      },
+      })),
       Target,
     ))
     .id();
@@ -221,12 +211,9 @@ impl AgentSpawner {
   fn spawn(&self, position: Vec2, commands: &mut Commands, fast_agent: bool) {
     let entity = commands
       .spawn((
-        MaterialMesh2dBundle {
-          transform: Transform::from_translation(position.extend(0.1)),
-          mesh: Mesh2d(self.mesh.clone()),
-          material: MeshMaterial2d(self.material.clone()),
-          ..Default::default()
-        },
+        Transform::from_translation(position.extend(0.1)),
+        Mesh2d(self.mesh.clone()),
+        MeshMaterial2d(self.material.clone()),
         Agent2dBundle {
           agent: Agent { radius: 0.5, desired_speed: 2.0, max_speed: 3.0 },
           archipelago_ref: ArchipelagoRef2d::new(self.archipelago_entity),

--- a/crates/bevy_landmass/example/main.rs
+++ b/crates/bevy_landmass/example/main.rs
@@ -215,7 +215,11 @@ impl AgentSpawner {
         Mesh2d(self.mesh.clone()),
         MeshMaterial2d(self.material.clone()),
         Agent2dBundle {
-          agent: Agent { radius: 0.5, desired_speed: 2.0, max_speed: 3.0 },
+          settings: AgentSettings {
+            radius: 0.5,
+            desired_speed: 2.0,
+            max_speed: 3.0,
+          },
           archipelago_ref: ArchipelagoRef2d::new(self.archipelago_entity),
           target: AgentTarget2d::Entity(self.target_entity),
           state: Default::default(),

--- a/crates/bevy_landmass/src/agent.rs
+++ b/crates/bevy_landmass/src/agent.rs
@@ -17,8 +17,8 @@ use crate::{ArchipelagoRef, NodeType};
 /// previous bundles).
 #[derive(Bundle)]
 pub struct AgentBundle<CS: CoordinateSystem> {
-  /// The agent itself.
-  pub agent: Agent,
+  /// The agent's settings.
+  pub settings: AgentSettings,
   /// A reference pointing to the Archipelago to associate this entity with.
   pub archipelago_ref: ArchipelagoRef<CS>,
   /// The velocity of the agent.
@@ -36,10 +36,11 @@ pub struct AgentBundle<CS: CoordinateSystem> {
 pub type Agent2dBundle = AgentBundle<TwoD>;
 pub type Agent3dBundle = AgentBundle<ThreeD>;
 
-/// An agent. See [`crate::AgentBundle`] for required related components.
+/// The settings for an agent. See [`crate::AgentBundle`] for required related
+/// components.
 #[derive(Component, Debug)]
 #[require(Transform)]
-pub struct Agent {
+pub struct AgentSettings {
   /// The radius of the agent.
   pub radius: f32,
   /// The speed the agent prefers to move at. This should often be set lower
@@ -176,7 +177,7 @@ impl<CS: CoordinateSystem> AgentDesiredVelocity<CS> {
 pub(crate) fn add_agents_to_archipelagos<CS: CoordinateSystem>(
   mut archipelago_query: Query<(Entity, &mut Archipelago<CS>)>,
   agent_query: Query<
-    (Entity, &Agent, &ArchipelagoRef<CS>),
+    (Entity, &AgentSettings, &ArchipelagoRef<CS>),
     With<GlobalTransform>,
   >,
 ) {
@@ -225,7 +226,7 @@ pub(crate) fn add_agents_to_archipelagos<CS: CoordinateSystem>(
 pub(crate) fn sync_agent_input_state<CS: CoordinateSystem>(
   agent_query: Query<(
     Entity,
-    &Agent,
+    &AgentSettings,
     &ArchipelagoRef<CS>,
     &GlobalTransform,
     Option<&Velocity<CS>>,
@@ -304,7 +305,7 @@ pub(crate) fn sync_agent_input_state<CS: CoordinateSystem>(
 pub(crate) fn sync_agent_state<CS: CoordinateSystem>(
   mut agent_query: Query<
     (Entity, &ArchipelagoRef<CS>, &mut AgentState),
-    With<Agent>,
+    With<AgentSettings>,
   >,
   archipelago_query: Query<&Archipelago<CS>>,
 ) {
@@ -330,7 +331,7 @@ pub(crate) fn sync_agent_state<CS: CoordinateSystem>(
 pub(crate) fn sync_desired_velocity<CS: CoordinateSystem>(
   mut agent_query: Query<
     (Entity, &ArchipelagoRef<CS>, &mut AgentDesiredVelocity<CS>),
-    With<Agent>,
+    With<AgentSettings>,
   >,
   archipelago_query: Query<&Archipelago<CS>>,
 ) {

--- a/crates/bevy_landmass/src/agent.rs
+++ b/crates/bevy_landmass/src/agent.rs
@@ -2,7 +2,7 @@ use bevy::{
   prelude::{
     Bundle, Component, Deref, DetectChanges, Entity, Query, Ref, With,
   },
-  transform::components::GlobalTransform,
+  transform::components::{GlobalTransform, Transform},
   utils::HashMap,
 };
 
@@ -38,6 +38,7 @@ pub type Agent3dBundle = AgentBundle<ThreeD>;
 
 /// An agent. See [`crate::AgentBundle`] for required related components.
 #[derive(Component, Debug)]
+#[require(Transform)]
 pub struct Agent {
   /// The radius of the agent.
   pub radius: f32,

--- a/crates/bevy_landmass/src/agent.rs
+++ b/crates/bevy_landmass/src/agent.rs
@@ -1,3 +1,5 @@
+use std::marker::PhantomData;
+
 use bevy::{
   prelude::{
     Bundle, Component, Deref, DetectChanges, Entity, Query, Ref, With,
@@ -17,29 +19,34 @@ use crate::{ArchipelagoRef, NodeType};
 /// previous bundles).
 #[derive(Bundle)]
 pub struct AgentBundle<CS: CoordinateSystem> {
+  /// The agent marker.
+  pub agent: Agent<CS>,
   /// The agent's settings.
   pub settings: AgentSettings,
   /// A reference pointing to the Archipelago to associate this entity with.
   pub archipelago_ref: ArchipelagoRef<CS>,
-  /// The velocity of the agent.
-  pub velocity: Velocity<CS>,
-  /// The target of the agent.
-  pub target: AgentTarget<CS>,
-  /// The current state of the agent. This is set by `landmass` (during
-  /// [`LandmassSystemSet::Output`]).
-  pub state: AgentState,
-  /// The current desired velocity of the agent. This is set by `landmass`
-  /// (during [`LandmassSystemSet::Output`]).
-  pub desired_velocity: AgentDesiredVelocity<CS>,
 }
 
 pub type Agent2dBundle = AgentBundle<TwoD>;
 pub type Agent3dBundle = AgentBundle<ThreeD>;
 
+/// A marker component to create all required components for an agent.
+#[derive(Component)]
+#[require(Transform, Velocity<CS>, AgentTarget<CS>, AgentState, AgentDesiredVelocity<CS>)]
+pub struct Agent<CS: CoordinateSystem>(PhantomData<CS>);
+
+pub type Agent2d = Agent<TwoD>;
+pub type Agent3d = Agent<ThreeD>;
+
+impl<CS: CoordinateSystem> Default for Agent<CS> {
+  fn default() -> Self {
+    Self(Default::default())
+  }
+}
+
 /// The settings for an agent. See [`crate::AgentBundle`] for required related
 /// components.
 #[derive(Component, Debug)]
-#[require(Transform)]
 pub struct AgentSettings {
   /// The radius of the agent.
   pub radius: f32,

--- a/crates/bevy_landmass/src/character.rs
+++ b/crates/bevy_landmass/src/character.rs
@@ -14,8 +14,8 @@ use crate::{
 /// override previous bundles).
 #[derive(Bundle)]
 pub struct CharacterBundle<CS: CoordinateSystem> {
-  /// The character itself.
-  pub character: Character,
+  /// The character's settings.
+  pub settings: CharacterSettings,
   /// A reference pointing to the Archipelago to associate this entity with.
   pub archipelago_ref: ArchipelagoRef<CS>,
   /// The velocity of the character.
@@ -25,10 +25,11 @@ pub struct CharacterBundle<CS: CoordinateSystem> {
 pub type Character2dBundle = CharacterBundle<TwoD>;
 pub type Character3dBundle = CharacterBundle<ThreeD>;
 
-/// A character. See [`crate::CharacterBundle`] for required related components.
+/// A character's settings. See [`crate::CharacterBundle`] for required related
+/// components.
 #[derive(Component, Debug)]
 #[require(Transform)]
-pub struct Character {
+pub struct CharacterSettings {
   /// The radius of the character.
   pub radius: f32,
 }
@@ -62,7 +63,7 @@ impl<CS: CoordinateSystem<Coordinate: std::fmt::Debug>> std::fmt::Debug
 pub(crate) fn add_characters_to_archipelago<CS: CoordinateSystem>(
   mut archipelagos: Query<(Entity, &mut Archipelago<CS>)>,
   characters: Query<
-    (Entity, &Character, &ArchipelagoRef<CS>),
+    (Entity, &CharacterSettings, &ArchipelagoRef<CS>),
     With<GlobalTransform>,
   >,
 ) {
@@ -103,7 +104,7 @@ pub(crate) fn add_characters_to_archipelago<CS: CoordinateSystem>(
 pub(crate) fn sync_character_state<CS: CoordinateSystem>(
   characters: Query<(
     Entity,
-    &Character,
+    &CharacterSettings,
     &ArchipelagoRef<CS>,
     &GlobalTransform,
     Option<&Velocity<CS>>,

--- a/crates/bevy_landmass/src/character.rs
+++ b/crates/bevy_landmass/src/character.rs
@@ -1,6 +1,6 @@
 use bevy::{
   prelude::{Bundle, Component, Entity, Query, With},
-  transform::components::GlobalTransform,
+  transform::components::{GlobalTransform, Transform},
   utils::hashbrown::HashMap,
 };
 
@@ -27,6 +27,7 @@ pub type Character3dBundle = CharacterBundle<ThreeD>;
 
 /// A character. See [`crate::CharacterBundle`] for required related components.
 #[derive(Component, Debug)]
+#[require(Transform)]
 pub struct Character {
   /// The radius of the character.
   pub radius: f32,

--- a/crates/bevy_landmass/src/character.rs
+++ b/crates/bevy_landmass/src/character.rs
@@ -1,3 +1,5 @@
+use std::marker::PhantomData;
+
 use bevy::{
   prelude::{Bundle, Component, Entity, Query, With},
   transform::components::{GlobalTransform, Transform},
@@ -14,21 +16,31 @@ use crate::{
 /// override previous bundles).
 #[derive(Bundle)]
 pub struct CharacterBundle<CS: CoordinateSystem> {
+  /// The character marker.
+  pub character: Character<CS>,
   /// The character's settings.
   pub settings: CharacterSettings,
   /// A reference pointing to the Archipelago to associate this entity with.
   pub archipelago_ref: ArchipelagoRef<CS>,
-  /// The velocity of the character.
-  pub velocity: Velocity<CS>,
 }
 
 pub type Character2dBundle = CharacterBundle<TwoD>;
 pub type Character3dBundle = CharacterBundle<ThreeD>;
 
+/// A marker component to create all required components for a character.
+#[derive(Component)]
+#[require(Transform, Velocity<CS>)]
+pub struct Character<CS: CoordinateSystem>(PhantomData<CS>);
+
+impl<CS: CoordinateSystem> Default for Character<CS> {
+  fn default() -> Self {
+    Self(Default::default())
+  }
+}
+
 /// A character's settings. See [`crate::CharacterBundle`] for required related
 /// components.
 #[derive(Component, Debug)]
-#[require(Transform)]
 pub struct CharacterSettings {
   /// The radius of the character.
   pub radius: f32,

--- a/crates/bevy_landmass/src/debug.rs
+++ b/crates/bevy_landmass/src/debug.rs
@@ -8,7 +8,7 @@ use bevy::{
   app::Update,
   color::Color,
   gizmos::AppGizmoBuilder,
-  math::Quat,
+  math::{Isometry3d, Quat},
   prelude::{
     Deref, DerefMut, GizmoConfig, GizmoConfigGroup, Gizmos, IntoSystemConfigs,
     Plugin, Query, Res, Resource,
@@ -86,8 +86,7 @@ impl<'w, 's, 'a, CS: CoordinateSystem> DebugDrawer<CS>
 {
   fn add_point(&mut self, point_type: PointType, point: CS::Coordinate) {
     self.0.sphere(
-      CS::to_world_position(&point),
-      Quat::IDENTITY,
+      Isometry3d::new(CS::to_world_position(&point), Quat::IDENTITY),
       0.2,
       match point_type {
         PointType::AgentPosition(_) => Color::srgba(0.0, 1.0, 0.0, 0.6),
@@ -143,7 +142,7 @@ fn draw_archipelagos_default<CS: CoordinateSystem>(
   archipelagos: Query<&Archipelago<CS>>,
   mut gizmos: Gizmos<'_, '_, LandmassGizmoConfigGroup>,
 ) {
-  if time.delta_seconds() == 0.0 {
+  if time.delta_secs() == 0.0 {
     return;
   }
   let mut drawer = GizmoDrawer(&mut gizmos, PhantomData::<CS>);

--- a/crates/bevy_landmass/src/island.rs
+++ b/crates/bevy_landmass/src/island.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use bevy::{
-  asset::{Assets, Handle},
+  asset::Assets,
   prelude::{Bundle, Component, Entity, Query, Res, With},
   transform::components::GlobalTransform,
   utils::hashbrown::{HashMap, HashSet},
@@ -9,7 +9,7 @@ use bevy::{
 
 use crate::{
   coords::{CoordinateSystem, ThreeD, TwoD},
-  Archipelago, ArchipelagoRef, NavMesh,
+  Archipelago, ArchipelagoRef, NavMesh, NavMeshHandle,
 };
 
 /// A bundle to create islands. The GlobalTransform component is omitted, since
@@ -22,7 +22,7 @@ pub struct IslandBundle<CS: CoordinateSystem> {
   /// A reference pointing to the Archipelago to associate this entity with.
   pub archipelago_ref: ArchipelagoRef<CS>,
   /// A handle to the nav mesh that this island needs.
-  pub nav_mesh: Handle<NavMesh<CS>>,
+  pub nav_mesh: NavMeshHandle<CS>,
 }
 
 pub type Island2dBundle = IslandBundle<TwoD>;
@@ -36,7 +36,7 @@ pub struct Island;
 pub(crate) fn sync_islands_to_archipelago<CS: CoordinateSystem>(
   mut archipelagos: Query<(Entity, &mut Archipelago<CS>)>,
   islands: Query<
-    (Entity, &Handle<NavMesh<CS>>, &GlobalTransform, &ArchipelagoRef<CS>),
+    (Entity, &NavMeshHandle<CS>, &GlobalTransform, &ArchipelagoRef<CS>),
     With<Island>,
   >,
   nav_meshes: Res<Assets<NavMesh<CS>>>,
@@ -50,7 +50,7 @@ pub(crate) fn sync_islands_to_archipelago<CS: CoordinateSystem>(
       Ok((_, arch)) => arch,
     };
 
-    let Some(island_nav_mesh) = nav_meshes.get(island_nav_mesh) else {
+    let Some(island_nav_mesh) = nav_meshes.get(&island_nav_mesh.0) else {
       continue;
     };
 

--- a/crates/bevy_landmass/src/island.rs
+++ b/crates/bevy_landmass/src/island.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use bevy::{
   asset::Assets,
   prelude::{Bundle, Component, Entity, Query, Res, With},
-  transform::components::GlobalTransform,
+  transform::components::{GlobalTransform, Transform},
   utils::hashbrown::{HashMap, HashSet},
 };
 
@@ -30,6 +30,7 @@ pub type Island3dBundle = IslandBundle<ThreeD>;
 
 /// A marker component that an entity is an island.
 #[derive(Component)]
+#[require(Transform)]
 pub struct Island;
 
 /// Ensures that the island transform and nav mesh are up to date.

--- a/crates/bevy_landmass/src/lib.rs
+++ b/crates/bevy_landmass/src/lib.rs
@@ -56,9 +56,9 @@ pub mod prelude {
   pub use crate::Archipelago3d;
   pub use crate::ArchipelagoRef2d;
   pub use crate::ArchipelagoRef3d;
-  pub use crate::Character;
   pub use crate::Character2dBundle;
   pub use crate::Character3dBundle;
+  pub use crate::CharacterSettings;
   pub use crate::Island;
   pub use crate::Island2dBundle;
   pub use crate::Island3dBundle;

--- a/crates/bevy_landmass/src/lib.rs
+++ b/crates/bevy_landmass/src/lib.rs
@@ -3,7 +3,7 @@
 use std::{collections::HashMap, marker::PhantomData, sync::Arc};
 
 use bevy::{
-  asset::{Asset, AssetApp},
+  asset::{Asset, AssetApp, Handle},
   prelude::{
     Component, Entity, IntoSystemConfigs, IntoSystemSetConfigs, Plugin, Query,
     Res, SystemSet, Update,
@@ -67,6 +67,8 @@ pub mod prelude {
   pub use crate::LandmassSystemSet;
   pub use crate::NavMesh2d;
   pub use crate::NavMesh3d;
+  pub use crate::NavMeshHandle2d;
+  pub use crate::NavMeshHandle3d;
   pub use crate::NavigationMesh2d;
   pub use crate::NavigationMesh3d;
   pub use crate::ValidNavigationMesh2d;
@@ -326,11 +328,11 @@ fn update_archipelagos<CS: CoordinateSystem>(
   time: Res<Time>,
   mut archipelago_query: Query<&mut Archipelago<CS>>,
 ) {
-  if time.delta_seconds() == 0.0 {
+  if time.delta_secs() == 0.0 {
     return;
   }
   for mut archipelago in archipelago_query.iter_mut() {
-    archipelago.archipelago.update(time.delta_seconds());
+    archipelago.archipelago.update(time.delta_secs());
   }
 }
 
@@ -381,6 +383,19 @@ pub struct NavMesh<CS: CoordinateSystem> {
 
 pub type NavMesh2d = NavMesh<TwoD>;
 pub type NavMesh3d = NavMesh<ThreeD>;
+
+/// A handle to a navigation mesh for an [`Island`].
+#[derive(Component, Clone, Debug)]
+pub struct NavMeshHandle<CS: CoordinateSystem>(pub Handle<NavMesh<CS>>);
+
+impl<CS: CoordinateSystem> Default for NavMeshHandle<CS> {
+  fn default() -> Self {
+    Self(Default::default())
+  }
+}
+
+pub type NavMeshHandle2d = NavMeshHandle<TwoD>;
+pub type NavMeshHandle3d = NavMeshHandle<ThreeD>;
 
 /// A point on the navigation meshes.
 pub struct SampledPoint<'archipelago, CS: CoordinateSystem> {

--- a/crates/bevy_landmass/src/lib.rs
+++ b/crates/bevy_landmass/src/lib.rs
@@ -44,11 +44,11 @@ pub mod prelude {
   pub use crate::coords::CoordinateSystem;
   pub use crate::coords::ThreeD;
   pub use crate::coords::TwoD;
-  pub use crate::Agent;
   pub use crate::Agent2dBundle;
   pub use crate::Agent3dBundle;
   pub use crate::AgentDesiredVelocity2d;
   pub use crate::AgentDesiredVelocity3d;
+  pub use crate::AgentSettings;
   pub use crate::AgentState;
   pub use crate::AgentTarget2d;
   pub use crate::AgentTarget3d;

--- a/crates/bevy_landmass/src/lib_test.rs
+++ b/crates/bevy_landmass/src/lib_test.rs
@@ -7,9 +7,9 @@ use crate::{
   Agent2dBundle, Agent3dBundle, AgentDesiredVelocity2d, AgentDesiredVelocity3d,
   AgentNodeTypeCostOverrides, AgentSettings, AgentState, AgentTarget2d,
   AgentTarget3d, Archipelago2d, Archipelago3d, ArchipelagoRef2d,
-  ArchipelagoRef3d, Character, Character3dBundle, Island, Island2dBundle,
-  Island3dBundle, Landmass2dPlugin, Landmass3dPlugin, NavMesh2d, NavMesh3d,
-  NavMeshHandle, NavigationMesh3d, Velocity3d,
+  ArchipelagoRef3d, Character3dBundle, CharacterSettings, Island,
+  Island2dBundle, Island3dBundle, Landmass2dPlugin, Landmass3dPlugin,
+  NavMesh2d, NavMesh3d, NavMeshHandle, NavigationMesh3d, Velocity3d,
 };
 
 #[test]
@@ -223,7 +223,7 @@ fn adds_and_removes_characters() {
   let character_id_1 = app
     .world_mut()
     .spawn((Character3dBundle {
-      character: Character { radius: 0.5 },
+      settings: CharacterSettings { radius: 0.5 },
       archipelago_ref: ArchipelagoRef3d::new(archipelago_id),
       velocity: Default::default(),
     },))
@@ -232,7 +232,7 @@ fn adds_and_removes_characters() {
   let character_id_2 = app
     .world_mut()
     .spawn((Character3dBundle {
-      character: Character { radius: 0.5 },
+      settings: CharacterSettings { radius: 0.5 },
       archipelago_ref: ArchipelagoRef3d::new(archipelago_id),
       velocity: Default::default(),
     },))
@@ -259,7 +259,7 @@ fn adds_and_removes_characters() {
   let character_id_3 = app
     .world_mut()
     .spawn((Character3dBundle {
-      character: Character { radius: 0.5 },
+      settings: CharacterSettings { radius: 0.5 },
       archipelago_ref: ArchipelagoRef3d::new(archipelago_id),
       velocity: Default::default(),
     },))
@@ -537,7 +537,7 @@ fn changing_character_fields_changes_landmass_character() {
     .spawn((
       Transform::from_translation(Vec3::new(1.0, 2.0, 3.0)),
       Character3dBundle {
-        character: Character { radius: 1.0 },
+        settings: CharacterSettings { radius: 1.0 },
         archipelago_ref: ArchipelagoRef3d::new(archipelago),
         velocity: Velocity3d { velocity: Vec3::new(4.0, 5.0, 6.0) },
       },
@@ -560,7 +560,7 @@ fn changing_character_fields_changes_landmass_character() {
 
   app.world_mut().entity_mut(character).insert((
     Transform::from_translation(Vec3::new(7.0, 8.0, 9.0)),
-    Character { radius: 2.0 },
+    CharacterSettings { radius: 2.0 },
     Velocity3d { velocity: Vec3::new(10.0, 11.0, 12.0) },
   ));
 

--- a/crates/bevy_landmass/src/lib_test.rs
+++ b/crates/bevy_landmass/src/lib_test.rs
@@ -223,18 +223,18 @@ fn adds_and_removes_characters() {
   let character_id_1 = app
     .world_mut()
     .spawn((Character3dBundle {
+      character: Default::default(),
       settings: CharacterSettings { radius: 0.5 },
       archipelago_ref: ArchipelagoRef3d::new(archipelago_id),
-      velocity: Default::default(),
     },))
     .id();
 
   let character_id_2 = app
     .world_mut()
     .spawn((Character3dBundle {
+      character: Default::default(),
       settings: CharacterSettings { radius: 0.5 },
       archipelago_ref: ArchipelagoRef3d::new(archipelago_id),
-      velocity: Default::default(),
     },))
     .id();
 
@@ -259,9 +259,9 @@ fn adds_and_removes_characters() {
   let character_id_3 = app
     .world_mut()
     .spawn((Character3dBundle {
+      character: Default::default(),
       settings: CharacterSettings { radius: 0.5 },
       archipelago_ref: ArchipelagoRef3d::new(archipelago_id),
-      velocity: Default::default(),
     },))
     .id();
 
@@ -537,10 +537,11 @@ fn changing_character_fields_changes_landmass_character() {
     .spawn((
       Transform::from_translation(Vec3::new(1.0, 2.0, 3.0)),
       Character3dBundle {
+        character: Default::default(),
         settings: CharacterSettings { radius: 1.0 },
         archipelago_ref: ArchipelagoRef3d::new(archipelago),
-        velocity: Velocity3d { velocity: Vec3::new(4.0, 5.0, 6.0) },
       },
+      Velocity3d { velocity: Vec3::new(4.0, 5.0, 6.0) },
     ))
     .id();
 

--- a/crates/bevy_landmass/src/lib_test.rs
+++ b/crates/bevy_landmass/src/lib_test.rs
@@ -9,7 +9,7 @@ use crate::{
   AgentTarget2d, AgentTarget3d, Archipelago2d, Archipelago3d, ArchipelagoRef2d,
   ArchipelagoRef3d, Character, Character3dBundle, Island, Island2dBundle,
   Island3dBundle, Landmass2dPlugin, Landmass3dPlugin, NavMesh2d, NavMesh3d,
-  NavigationMesh3d, Velocity3d,
+  NavMeshHandle, NavigationMesh3d, Velocity3d,
 };
 
 #[test]
@@ -59,7 +59,7 @@ fn computes_path_for_agent_and_updates_desired_velocity() {
       archipelago_ref: ArchipelagoRef3d::new(archipelago_id),
       nav_mesh: Default::default(),
     })
-    .insert(nav_mesh_handle.clone());
+    .insert(NavMeshHandle(nav_mesh_handle.clone()));
 
   app.world_mut().resource_mut::<Assets<NavMesh3d>>().insert(
     &nav_mesh_handle,
@@ -350,7 +350,7 @@ fn adds_and_removes_islands() {
     .insert(Island3dBundle {
       island: Island,
       archipelago_ref: ArchipelagoRef3d::new(archipelago_id),
-      nav_mesh: nav_mesh.clone(),
+      nav_mesh: NavMeshHandle(nav_mesh.clone()),
     })
     .id();
 
@@ -360,7 +360,7 @@ fn adds_and_removes_islands() {
     .insert(Island3dBundle {
       island: Island,
       archipelago_ref: ArchipelagoRef3d::new(archipelago_id),
-      nav_mesh: nav_mesh.clone(),
+      nav_mesh: NavMeshHandle(nav_mesh.clone()),
     })
     .id();
 
@@ -392,7 +392,7 @@ fn adds_and_removes_islands() {
     .insert(Island3dBundle {
       island: Island,
       archipelago_ref: ArchipelagoRef3d::new(archipelago_id),
-      nav_mesh: nav_mesh.clone(),
+      nav_mesh: NavMeshHandle(nav_mesh.clone()),
     })
     .id();
 
@@ -668,7 +668,7 @@ fn node_type_costs_are_used() {
   app.world_mut().spawn(TransformBundle::default()).insert(Island2dBundle {
     island: Island,
     archipelago_ref: ArchipelagoRef2d::new(archipelago_id),
-    nav_mesh: nav_mesh_handle.clone(),
+    nav_mesh: NavMeshHandle(nav_mesh_handle.clone()),
   });
 
   app.world_mut().resource_mut::<Assets<NavMesh2d>>().insert(
@@ -785,7 +785,7 @@ fn overridden_node_type_costs_are_used() {
   app.world_mut().spawn(TransformBundle::default()).insert(Island2dBundle {
     island: Island,
     archipelago_ref: ArchipelagoRef2d::new(archipelago_id),
-    nav_mesh: nav_mesh_handle.clone(),
+    nav_mesh: NavMeshHandle(nav_mesh_handle.clone()),
   });
 
   app.world_mut().resource_mut::<Assets<NavMesh2d>>().insert(
@@ -873,7 +873,7 @@ fn sample_point_error_on_out_of_range() {
     Island2dBundle {
       island: Island,
       archipelago_ref: ArchipelagoRef2d::new(archipelago_entity),
-      nav_mesh: nav_mesh_handle,
+      nav_mesh: NavMeshHandle(nav_mesh_handle),
     },
   ));
 
@@ -934,7 +934,7 @@ fn samples_point_on_nav_mesh_or_near_nav_mesh() {
       Island2dBundle {
         island: Island,
         archipelago_ref: ArchipelagoRef2d::new(archipelago_entity),
-        nav_mesh: nav_mesh_handle,
+        nav_mesh: NavMeshHandle(nav_mesh_handle),
       },
     ))
     .id();
@@ -1022,7 +1022,7 @@ fn samples_node_types() {
     Island2dBundle {
       island: Island,
       archipelago_ref: ArchipelagoRef2d::new(archipelago_entity),
-      nav_mesh: nav_mesh_handle,
+      nav_mesh: NavMeshHandle(nav_mesh_handle),
     },
   ));
 
@@ -1095,7 +1095,7 @@ fn finds_path() {
     Island2dBundle {
       island: Island,
       archipelago_ref: ArchipelagoRef2d::new(archipelago_entity),
-      nav_mesh: nav_mesh.clone(),
+      nav_mesh: NavMeshHandle(nav_mesh.clone()),
     },
   ));
 
@@ -1107,7 +1107,7 @@ fn finds_path() {
     Island2dBundle {
       island: Island,
       archipelago_ref: ArchipelagoRef2d::new(archipelago_entity),
-      nav_mesh: nav_mesh.clone(),
+      nav_mesh: NavMeshHandle(nav_mesh.clone()),
     },
   ));
 
@@ -1119,7 +1119,7 @@ fn finds_path() {
     Island2dBundle {
       island: Island,
       archipelago_ref: ArchipelagoRef2d::new(archipelago_entity),
-      nav_mesh: nav_mesh.clone(),
+      nav_mesh: NavMeshHandle(nav_mesh.clone()),
     },
   ));
 
@@ -1185,7 +1185,7 @@ fn island_matches_rotation_3d() {
       Island3dBundle {
         island: Island,
         archipelago_ref: ArchipelagoRef3d::new(archipelago_entity),
-        nav_mesh: nav_mesh.clone(),
+        nav_mesh: NavMeshHandle(nav_mesh.clone()),
       },
     ))
     .id();
@@ -1246,7 +1246,7 @@ fn island_matches_rotation_2d() {
       Island2dBundle {
         island: Island,
         archipelago_ref: ArchipelagoRef2d::new(archipelago_entity),
-        nav_mesh: nav_mesh.clone(),
+        nav_mesh: NavMeshHandle(nav_mesh.clone()),
       },
     ))
     .id();

--- a/crates/bevy_landmass/src/lib_test.rs
+++ b/crates/bevy_landmass/src/lib_test.rs
@@ -67,17 +67,15 @@ fn computes_path_for_agent_and_updates_desired_velocity() {
     .spawn((
       Transform::from_translation(Vec3::new(2.5, 1.0, 2.5)),
       Agent3dBundle {
+        agent: Default::default(),
         settings: AgentSettings {
           radius: 0.5,
           desired_speed: 1.0,
           max_speed: 2.0,
         },
         archipelago_ref: ArchipelagoRef3d::new(archipelago_id),
-        target: AgentTarget3d::Point(Vec3::new(4.5, 1.0, 4.5)),
-        velocity: Default::default(),
-        state: Default::default(),
-        desired_velocity: Default::default(),
       },
+      AgentTarget3d::Point(Vec3::new(4.5, 1.0, 4.5)),
     ))
     .id();
 
@@ -115,32 +113,26 @@ fn adds_and_removes_agents() {
   let agent_id_1 = app
     .world_mut()
     .spawn(Agent3dBundle {
+      agent: Default::default(),
       settings: AgentSettings {
         radius: 0.5,
         desired_speed: 1.0,
         max_speed: 2.0,
       },
       archipelago_ref: ArchipelagoRef3d::new(archipelago_id),
-      target: AgentTarget3d::None,
-      velocity: Default::default(),
-      state: Default::default(),
-      desired_velocity: Default::default(),
     })
     .id();
 
   let agent_id_2 = app
     .world_mut()
     .spawn(Agent3dBundle {
+      agent: Default::default(),
       settings: AgentSettings {
         radius: 0.5,
         desired_speed: 1.0,
         max_speed: 2.0,
       },
       archipelago_ref: ArchipelagoRef3d::new(archipelago_id),
-      target: AgentTarget3d::None,
-      velocity: Default::default(),
-      state: Default::default(),
-      desired_velocity: Default::default(),
     })
     .id();
 
@@ -165,16 +157,13 @@ fn adds_and_removes_agents() {
   let agent_id_3 = app
     .world_mut()
     .spawn(Agent3dBundle {
+      agent: Default::default(),
       settings: AgentSettings {
         radius: 0.5,
         desired_speed: 1.0,
         max_speed: 2.0,
       },
       archipelago_ref: ArchipelagoRef3d::new(archipelago_id),
-      target: AgentTarget3d::None,
-      velocity: Default::default(),
-      state: Default::default(),
-      desired_velocity: Default::default(),
     })
     .id();
 
@@ -463,17 +452,15 @@ fn changing_agent_fields_changes_landmass_agent() {
     .spawn((
       Transform::from_translation(Vec3::new(1.0, 2.0, 3.0)),
       Agent3dBundle {
+        agent: Default::default(),
         settings: AgentSettings {
           radius: 1.0,
           desired_speed: 1.0,
           max_speed: 2.0,
         },
         archipelago_ref: ArchipelagoRef3d::new(archipelago),
-        velocity: Velocity3d { velocity: Vec3::new(4.0, 5.0, 6.0) },
-        target: AgentTarget3d::None,
-        state: Default::default(),
-        desired_velocity: Default::default(),
       },
+      Velocity3d { velocity: Vec3::new(4.0, 5.0, 6.0) },
       crate::TargetReachedCondition::Distance(Some(1.0)),
     ))
     .id();
@@ -678,17 +665,15 @@ fn node_type_costs_are_used() {
     .spawn((
       Transform::from_translation(Vec3::new(0.5, 0.5, 1.0)),
       Agent2dBundle {
+        agent: Default::default(),
         settings: AgentSettings {
           radius: 0.5,
           desired_speed: 1.0,
           max_speed: 2.0,
         },
         archipelago_ref: ArchipelagoRef2d::new(archipelago_id),
-        target: AgentTarget2d::Point(Vec2::new(0.5, 11.5)),
-        velocity: Default::default(),
-        state: Default::default(),
-        desired_velocity: Default::default(),
       },
+      AgentTarget2d::Point(Vec2::new(0.5, 11.5)),
     ))
     .id();
 
@@ -798,17 +783,15 @@ fn overridden_node_type_costs_are_used() {
     .spawn((
       Transform::from_translation(Vec3::new(0.5, 0.5, 1.0)),
       Agent2dBundle {
+        agent: Default::default(),
         settings: AgentSettings {
           radius: 0.5,
           desired_speed: 1.0,
           max_speed: 2.0,
         },
         archipelago_ref: ArchipelagoRef2d::new(archipelago_id),
-        target: AgentTarget2d::Point(Vec2::new(0.5, 11.5)),
-        velocity: Default::default(),
-        state: Default::default(),
-        desired_velocity: Default::default(),
       },
+      AgentTarget2d::Point(Vec2::new(0.5, 11.5)),
       {
         let mut overrides = AgentNodeTypeCostOverrides::default();
         overrides.set_node_type_cost(slow_node_type, 10.0);

--- a/crates/bevy_landmass/src/lib_test.rs
+++ b/crates/bevy_landmass/src/lib_test.rs
@@ -48,18 +48,14 @@ fn computes_path_for_agent_and_updates_desired_velocity() {
     .reserve_handle()
     .typed::<NavMesh3d>();
 
-  app
-    .world_mut()
-    .spawn(TransformBundle {
-      local: Transform::from_translation(Vec3::new(1.0, 1.0, 1.0)),
-      ..Default::default()
-    })
-    .insert(Island3dBundle {
+  app.world_mut().spawn((
+    Transform::from_translation(Vec3::new(1.0, 1.0, 1.0)),
+    Island3dBundle {
       island: Island,
       archipelago_ref: ArchipelagoRef3d::new(archipelago_id),
-      nav_mesh: Default::default(),
-    })
-    .insert(NavMeshHandle(nav_mesh_handle.clone()));
+      nav_mesh: NavMeshHandle(nav_mesh_handle.clone()),
+    },
+  ));
 
   app.world_mut().resource_mut::<Assets<NavMesh3d>>().insert(
     &nav_mesh_handle,
@@ -68,18 +64,17 @@ fn computes_path_for_agent_and_updates_desired_velocity() {
 
   let agent_id = app
     .world_mut()
-    .spawn(TransformBundle {
-      local: Transform::from_translation(Vec3::new(2.5, 1.0, 2.5)),
-      ..Default::default()
-    })
-    .insert(Agent3dBundle {
-      agent: Agent { radius: 0.5, desired_speed: 1.0, max_speed: 2.0 },
-      archipelago_ref: ArchipelagoRef3d::new(archipelago_id),
-      target: AgentTarget3d::Point(Vec3::new(4.5, 1.0, 4.5)),
-      velocity: Default::default(),
-      state: Default::default(),
-      desired_velocity: Default::default(),
-    })
+    .spawn((
+      Transform::from_translation(Vec3::new(2.5, 1.0, 2.5)),
+      Agent3dBundle {
+        agent: Agent { radius: 0.5, desired_speed: 1.0, max_speed: 2.0 },
+        archipelago_ref: ArchipelagoRef3d::new(archipelago_id),
+        target: AgentTarget3d::Point(Vec3::new(4.5, 1.0, 4.5)),
+        velocity: Default::default(),
+        state: Default::default(),
+        desired_velocity: Default::default(),
+      },
+    ))
     .id();
 
   // The first update propagates the global transform, and sets the start of
@@ -115,8 +110,7 @@ fn adds_and_removes_agents() {
 
   let agent_id_1 = app
     .world_mut()
-    .spawn(TransformBundle::default())
-    .insert(Agent3dBundle {
+    .spawn(Agent3dBundle {
       agent: Agent { radius: 0.5, desired_speed: 1.0, max_speed: 2.0 },
       archipelago_ref: ArchipelagoRef3d::new(archipelago_id),
       target: AgentTarget3d::None,
@@ -128,8 +122,7 @@ fn adds_and_removes_agents() {
 
   let agent_id_2 = app
     .world_mut()
-    .spawn(TransformBundle::default())
-    .insert(Agent3dBundle {
+    .spawn(Agent3dBundle {
       agent: Agent { radius: 0.5, desired_speed: 1.0, max_speed: 2.0 },
       archipelago_ref: ArchipelagoRef3d::new(archipelago_id),
       target: AgentTarget3d::None,
@@ -159,8 +152,7 @@ fn adds_and_removes_agents() {
 
   let agent_id_3 = app
     .world_mut()
-    .spawn(TransformBundle::default())
-    .insert(Agent3dBundle {
+    .spawn(Agent3dBundle {
       agent: Agent { radius: 0.5, desired_speed: 1.0, max_speed: 2.0 },
       archipelago_ref: ArchipelagoRef3d::new(archipelago_id),
       target: AgentTarget3d::None,
@@ -225,26 +217,20 @@ fn adds_and_removes_characters() {
 
   let character_id_1 = app
     .world_mut()
-    .spawn((
-      TransformBundle::default(),
-      Character3dBundle {
-        character: Character { radius: 0.5 },
-        archipelago_ref: ArchipelagoRef3d::new(archipelago_id),
-        velocity: Default::default(),
-      },
-    ))
+    .spawn((Character3dBundle {
+      character: Character { radius: 0.5 },
+      archipelago_ref: ArchipelagoRef3d::new(archipelago_id),
+      velocity: Default::default(),
+    },))
     .id();
 
   let character_id_2 = app
     .world_mut()
-    .spawn((
-      TransformBundle::default(),
-      Character3dBundle {
-        character: Character { radius: 0.5 },
-        archipelago_ref: ArchipelagoRef3d::new(archipelago_id),
-        velocity: Default::default(),
-      },
-    ))
+    .spawn((Character3dBundle {
+      character: Character { radius: 0.5 },
+      archipelago_ref: ArchipelagoRef3d::new(archipelago_id),
+      velocity: Default::default(),
+    },))
     .id();
 
   app.update();
@@ -267,14 +253,11 @@ fn adds_and_removes_characters() {
 
   let character_id_3 = app
     .world_mut()
-    .spawn((
-      TransformBundle::default(),
-      Character3dBundle {
-        character: Character { radius: 0.5 },
-        archipelago_ref: ArchipelagoRef3d::new(archipelago_id),
-        velocity: Default::default(),
-      },
-    ))
+    .spawn((Character3dBundle {
+      character: Character { radius: 0.5 },
+      archipelago_ref: ArchipelagoRef3d::new(archipelago_id),
+      velocity: Default::default(),
+    },))
     .id();
 
   app.update();
@@ -346,8 +329,7 @@ fn adds_and_removes_islands() {
 
   let island_id_1 = app
     .world_mut()
-    .spawn(TransformBundle::default())
-    .insert(Island3dBundle {
+    .spawn(Island3dBundle {
       island: Island,
       archipelago_ref: ArchipelagoRef3d::new(archipelago_id),
       nav_mesh: NavMeshHandle(nav_mesh.clone()),
@@ -356,8 +338,7 @@ fn adds_and_removes_islands() {
 
   let island_id_2 = app
     .world_mut()
-    .spawn(TransformBundle::default())
-    .insert(Island3dBundle {
+    .spawn(Island3dBundle {
       island: Island,
       archipelago_ref: ArchipelagoRef3d::new(archipelago_id),
       nav_mesh: NavMeshHandle(nav_mesh.clone()),
@@ -388,8 +369,7 @@ fn adds_and_removes_islands() {
 
   let island_id_3 = app
     .world_mut()
-    .spawn(TransformBundle::default())
-    .insert(Island3dBundle {
+    .spawn(Island3dBundle {
       island: Island,
       archipelago_ref: ArchipelagoRef3d::new(archipelago_id),
       nav_mesh: NavMeshHandle(nav_mesh.clone()),
@@ -465,10 +445,7 @@ fn changing_agent_fields_changes_landmass_agent() {
   let agent = app
     .world_mut()
     .spawn((
-      TransformBundle {
-        local: Transform::from_translation(Vec3::new(1.0, 2.0, 3.0)),
-        ..Default::default()
-      },
+      Transform::from_translation(Vec3::new(1.0, 2.0, 3.0)),
       Agent3dBundle {
         agent: Agent { radius: 1.0, desired_speed: 1.0, max_speed: 2.0 },
         archipelago_ref: ArchipelagoRef3d::new(archipelago),
@@ -551,10 +528,7 @@ fn changing_character_fields_changes_landmass_character() {
   let character = app
     .world_mut()
     .spawn((
-      TransformBundle {
-        local: Transform::from_translation(Vec3::new(1.0, 2.0, 3.0)),
-        ..Default::default()
-      },
+      Transform::from_translation(Vec3::new(1.0, 2.0, 3.0)),
       Character3dBundle {
         character: Character { radius: 1.0 },
         archipelago_ref: ArchipelagoRef3d::new(archipelago),
@@ -665,7 +639,7 @@ fn node_type_costs_are_used() {
     .reserve_handle()
     .typed::<NavMesh2d>();
 
-  app.world_mut().spawn(TransformBundle::default()).insert(Island2dBundle {
+  app.world_mut().spawn(Island2dBundle {
     island: Island,
     archipelago_ref: ArchipelagoRef2d::new(archipelago_id),
     nav_mesh: NavMeshHandle(nav_mesh_handle.clone()),
@@ -681,18 +655,17 @@ fn node_type_costs_are_used() {
 
   let agent_id = app
     .world_mut()
-    .spawn(TransformBundle {
-      local: Transform::from_translation(Vec3::new(0.5, 0.5, 1.0)),
-      ..Default::default()
-    })
-    .insert(Agent2dBundle {
-      agent: Agent { radius: 0.5, desired_speed: 1.0, max_speed: 2.0 },
-      archipelago_ref: ArchipelagoRef2d::new(archipelago_id),
-      target: AgentTarget2d::Point(Vec2::new(0.5, 11.5)),
-      velocity: Default::default(),
-      state: Default::default(),
-      desired_velocity: Default::default(),
-    })
+    .spawn((
+      Transform::from_translation(Vec3::new(0.5, 0.5, 1.0)),
+      Agent2dBundle {
+        agent: Agent { radius: 0.5, desired_speed: 1.0, max_speed: 2.0 },
+        archipelago_ref: ArchipelagoRef2d::new(archipelago_id),
+        target: AgentTarget2d::Point(Vec2::new(0.5, 11.5)),
+        velocity: Default::default(),
+        state: Default::default(),
+        desired_velocity: Default::default(),
+      },
+    ))
     .id();
 
   // The first update propagates the global transform, and sets the start of
@@ -782,7 +755,7 @@ fn overridden_node_type_costs_are_used() {
     .reserve_handle()
     .typed::<NavMesh2d>();
 
-  app.world_mut().spawn(TransformBundle::default()).insert(Island2dBundle {
+  app.world_mut().spawn(Island2dBundle {
     island: Island,
     archipelago_ref: ArchipelagoRef2d::new(archipelago_id),
     nav_mesh: NavMeshHandle(nav_mesh_handle.clone()),
@@ -798,23 +771,22 @@ fn overridden_node_type_costs_are_used() {
 
   let agent_id = app
     .world_mut()
-    .spawn(TransformBundle {
-      local: Transform::from_translation(Vec3::new(0.5, 0.5, 1.0)),
-      ..Default::default()
-    })
-    .insert(Agent2dBundle {
-      agent: Agent { radius: 0.5, desired_speed: 1.0, max_speed: 2.0 },
-      archipelago_ref: ArchipelagoRef2d::new(archipelago_id),
-      target: AgentTarget2d::Point(Vec2::new(0.5, 11.5)),
-      velocity: Default::default(),
-      state: Default::default(),
-      desired_velocity: Default::default(),
-    })
-    .insert({
-      let mut overrides = AgentNodeTypeCostOverrides::default();
-      overrides.set_node_type_cost(slow_node_type, 10.0);
-      overrides
-    })
+    .spawn((
+      Transform::from_translation(Vec3::new(0.5, 0.5, 1.0)),
+      Agent2dBundle {
+        agent: Agent { radius: 0.5, desired_speed: 1.0, max_speed: 2.0 },
+        archipelago_ref: ArchipelagoRef2d::new(archipelago_id),
+        target: AgentTarget2d::Point(Vec2::new(0.5, 11.5)),
+        velocity: Default::default(),
+        state: Default::default(),
+        desired_velocity: Default::default(),
+      },
+      {
+        let mut overrides = AgentNodeTypeCostOverrides::default();
+        overrides.set_node_type_cost(slow_node_type, 10.0);
+        overrides
+      },
+    ))
     .id();
 
   // The first update propagates the global transform, and sets the start of
@@ -868,14 +840,11 @@ fn sample_point_error_on_out_of_range() {
     .resource_mut::<Assets<NavMesh2d>>()
     .add(NavMesh2d { nav_mesh, type_index_to_node_type: HashMap::new() });
 
-  app.world_mut().spawn((
-    TransformBundle::default(),
-    Island2dBundle {
-      island: Island,
-      archipelago_ref: ArchipelagoRef2d::new(archipelago_entity),
-      nav_mesh: NavMeshHandle(nav_mesh_handle),
-    },
-  ));
+  app.world_mut().spawn((Island2dBundle {
+    island: Island,
+    archipelago_ref: ArchipelagoRef2d::new(archipelago_entity),
+    nav_mesh: NavMeshHandle(nav_mesh_handle),
+  },));
 
   // The first update propagates the global transform, and sets the start of
   // the delta time (in this update, delta time is 0).
@@ -927,10 +896,7 @@ fn samples_point_on_nav_mesh_or_near_nav_mesh() {
   let island_id = app
     .world_mut()
     .spawn((
-      TransformBundle {
-        local: Transform::from_translation(offset.extend(0.0)),
-        ..Default::default()
-      },
+      Transform::from_translation(offset.extend(0.0)),
       Island2dBundle {
         island: Island,
         archipelago_ref: ArchipelagoRef2d::new(archipelago_entity),
@@ -1015,10 +981,7 @@ fn samples_node_types() {
 
   let offset = Vec2::new(10.0, 10.0);
   app.world_mut().spawn((
-    TransformBundle {
-      local: Transform::from_translation(offset.extend(0.0)),
-      ..Default::default()
-    },
+    Transform::from_translation(offset.extend(0.0)),
     Island2dBundle {
       island: Island,
       archipelago_ref: ArchipelagoRef2d::new(archipelago_entity),
@@ -1087,11 +1050,14 @@ fn finds_path() {
     .resource_mut::<Assets<NavMesh2d>>()
     .add(NavMesh2d { nav_mesh, type_index_to_node_type: HashMap::new() });
 
+  app.world_mut().spawn((Island2dBundle {
+    island: Island,
+    archipelago_ref: ArchipelagoRef2d::new(archipelago_entity),
+    nav_mesh: NavMeshHandle(nav_mesh.clone()),
+  },));
+
   app.world_mut().spawn((
-    TransformBundle {
-      local: Transform::from_translation(Vec3::ZERO),
-      ..Default::default()
-    },
+    Transform::from_translation(Vec3::new(1.0, 0.0, 0.0)),
     Island2dBundle {
       island: Island,
       archipelago_ref: ArchipelagoRef2d::new(archipelago_entity),
@@ -1100,22 +1066,7 @@ fn finds_path() {
   ));
 
   app.world_mut().spawn((
-    TransformBundle {
-      local: Transform::from_translation(Vec3::new(1.0, 0.0, 0.0)),
-      ..Default::default()
-    },
-    Island2dBundle {
-      island: Island,
-      archipelago_ref: ArchipelagoRef2d::new(archipelago_entity),
-      nav_mesh: NavMeshHandle(nav_mesh.clone()),
-    },
-  ));
-
-  app.world_mut().spawn((
-    TransformBundle {
-      local: Transform::from_translation(Vec3::new(2.0, 0.5, 0.0)),
-      ..Default::default()
-    },
+    Transform::from_translation(Vec3::new(2.0, 0.5, 0.0)),
     Island2dBundle {
       island: Island,
       archipelago_ref: ArchipelagoRef2d::new(archipelago_entity),
@@ -1178,10 +1129,7 @@ fn island_matches_rotation_3d() {
   let island = app
     .world_mut()
     .spawn((
-      TransformBundle {
-        local: Transform::from_rotation(Quat::from_rotation_y(2.0)),
-        ..Default::default()
-      },
+      Transform::from_rotation(Quat::from_rotation_y(2.0)),
       Island3dBundle {
         island: Island,
         archipelago_ref: ArchipelagoRef3d::new(archipelago_entity),
@@ -1239,10 +1187,7 @@ fn island_matches_rotation_2d() {
   let island = app
     .world_mut()
     .spawn((
-      TransformBundle {
-        local: Transform::from_rotation(Quat::from_rotation_z(2.0)),
-        ..Default::default()
-      },
+      Transform::from_rotation(Quat::from_rotation_z(2.0)),
       Island2dBundle {
         island: Island,
         archipelago_ref: ArchipelagoRef2d::new(archipelago_entity),

--- a/crates/bevy_landmass/src/lib_test.rs
+++ b/crates/bevy_landmass/src/lib_test.rs
@@ -4,9 +4,9 @@ use bevy::prelude::*;
 use landmass::{NavigationMesh, SamplePointError};
 
 use crate::{
-  Agent, Agent2dBundle, Agent3dBundle, AgentDesiredVelocity2d,
-  AgentDesiredVelocity3d, AgentNodeTypeCostOverrides, AgentState,
-  AgentTarget2d, AgentTarget3d, Archipelago2d, Archipelago3d, ArchipelagoRef2d,
+  Agent2dBundle, Agent3dBundle, AgentDesiredVelocity2d, AgentDesiredVelocity3d,
+  AgentNodeTypeCostOverrides, AgentSettings, AgentState, AgentTarget2d,
+  AgentTarget3d, Archipelago2d, Archipelago3d, ArchipelagoRef2d,
   ArchipelagoRef3d, Character, Character3dBundle, Island, Island2dBundle,
   Island3dBundle, Landmass2dPlugin, Landmass3dPlugin, NavMesh2d, NavMesh3d,
   NavMeshHandle, NavigationMesh3d, Velocity3d,
@@ -67,7 +67,11 @@ fn computes_path_for_agent_and_updates_desired_velocity() {
     .spawn((
       Transform::from_translation(Vec3::new(2.5, 1.0, 2.5)),
       Agent3dBundle {
-        agent: Agent { radius: 0.5, desired_speed: 1.0, max_speed: 2.0 },
+        settings: AgentSettings {
+          radius: 0.5,
+          desired_speed: 1.0,
+          max_speed: 2.0,
+        },
         archipelago_ref: ArchipelagoRef3d::new(archipelago_id),
         target: AgentTarget3d::Point(Vec3::new(4.5, 1.0, 4.5)),
         velocity: Default::default(),
@@ -111,7 +115,11 @@ fn adds_and_removes_agents() {
   let agent_id_1 = app
     .world_mut()
     .spawn(Agent3dBundle {
-      agent: Agent { radius: 0.5, desired_speed: 1.0, max_speed: 2.0 },
+      settings: AgentSettings {
+        radius: 0.5,
+        desired_speed: 1.0,
+        max_speed: 2.0,
+      },
       archipelago_ref: ArchipelagoRef3d::new(archipelago_id),
       target: AgentTarget3d::None,
       velocity: Default::default(),
@@ -123,7 +131,11 @@ fn adds_and_removes_agents() {
   let agent_id_2 = app
     .world_mut()
     .spawn(Agent3dBundle {
-      agent: Agent { radius: 0.5, desired_speed: 1.0, max_speed: 2.0 },
+      settings: AgentSettings {
+        radius: 0.5,
+        desired_speed: 1.0,
+        max_speed: 2.0,
+      },
       archipelago_ref: ArchipelagoRef3d::new(archipelago_id),
       target: AgentTarget3d::None,
       velocity: Default::default(),
@@ -153,7 +165,11 @@ fn adds_and_removes_agents() {
   let agent_id_3 = app
     .world_mut()
     .spawn(Agent3dBundle {
-      agent: Agent { radius: 0.5, desired_speed: 1.0, max_speed: 2.0 },
+      settings: AgentSettings {
+        radius: 0.5,
+        desired_speed: 1.0,
+        max_speed: 2.0,
+      },
       archipelago_ref: ArchipelagoRef3d::new(archipelago_id),
       target: AgentTarget3d::None,
       velocity: Default::default(),
@@ -447,7 +463,11 @@ fn changing_agent_fields_changes_landmass_agent() {
     .spawn((
       Transform::from_translation(Vec3::new(1.0, 2.0, 3.0)),
       Agent3dBundle {
-        agent: Agent { radius: 1.0, desired_speed: 1.0, max_speed: 2.0 },
+        settings: AgentSettings {
+          radius: 1.0,
+          desired_speed: 1.0,
+          max_speed: 2.0,
+        },
         archipelago_ref: ArchipelagoRef3d::new(archipelago),
         velocity: Velocity3d { velocity: Vec3::new(4.0, 5.0, 6.0) },
         target: AgentTarget3d::None,
@@ -483,7 +503,7 @@ fn changing_agent_fields_changes_landmass_agent() {
 
   app.world_mut().entity_mut(agent).insert((
     Transform::from_translation(Vec3::new(7.0, 8.0, 9.0)),
-    Agent { radius: 2.0, desired_speed: 1.5, max_speed: 2.0 },
+    AgentSettings { radius: 2.0, desired_speed: 1.5, max_speed: 2.0 },
     Velocity3d { velocity: Vec3::new(10.0, 11.0, 12.0) },
     AgentTarget3d::Point(Vec3::new(13.0, 14.0, 15.0)),
     crate::TargetReachedCondition::VisibleAtDistance(Some(2.0)),
@@ -658,7 +678,11 @@ fn node_type_costs_are_used() {
     .spawn((
       Transform::from_translation(Vec3::new(0.5, 0.5, 1.0)),
       Agent2dBundle {
-        agent: Agent { radius: 0.5, desired_speed: 1.0, max_speed: 2.0 },
+        settings: AgentSettings {
+          radius: 0.5,
+          desired_speed: 1.0,
+          max_speed: 2.0,
+        },
         archipelago_ref: ArchipelagoRef2d::new(archipelago_id),
         target: AgentTarget2d::Point(Vec2::new(0.5, 11.5)),
         velocity: Default::default(),
@@ -774,7 +798,11 @@ fn overridden_node_type_costs_are_used() {
     .spawn((
       Transform::from_translation(Vec3::new(0.5, 0.5, 1.0)),
       Agent2dBundle {
-        agent: Agent { radius: 0.5, desired_speed: 1.0, max_speed: 2.0 },
+        settings: AgentSettings {
+          radius: 0.5,
+          desired_speed: 1.0,
+          max_speed: 2.0,
+        },
         archipelago_ref: ArchipelagoRef2d::new(archipelago_id),
         target: AgentTarget2d::Point(Vec2::new(0.5, 11.5)),
         velocity: Default::default(),

--- a/crates/landmass_oxidized_navigation/Cargo.toml
+++ b/crates/landmass_oxidized_navigation/Cargo.toml
@@ -22,7 +22,7 @@ type_complexity = "allow"
 bevy = { version = "0.14.0", default-features = false, features = [
   "bevy_asset",
 ] }
-bevy_landmass = { path = "../bevy_landmass", version = "0.8.0-dev" }
+bevy_landmass = { version = "0.7.0" }
 oxidized_navigation = "0.11.0"
 
 [dev-dependencies]


### PR DESCRIPTION
Now we're (mostly) ready for Bevy 0.15.0! The exception is `landmass_oxidized_navigation`, which needs to wait for `oxidized_navigation`, which itself needs to wait for `rapier` and `avian`.

There's stuff I want to do before we release the new version (to also release a new `landmass` version).