### PR TITLE
Make `Archipelago::new` take an `AgentOptions`.

### DIFF
--- a/crates/bevy_landmass/README.md
+++ b/crates/bevy_landmass/README.md
@@ -45,8 +45,9 @@ fn set_up_scene(
   mut commands: Commands,
   mut nav_meshes: ResMut<Assets<NavMesh2d>>,
 ) {
-  let archipelago_id =
-    commands.spawn(Archipelago2d::new(AgentOptions::default())).id();
+  let archipelago_id = commands
+    .spawn(Archipelago2d::new(AgentOptions::default_for_agent_radius(0.5)))
+    .id();
 
   let nav_mesh_handle = nav_meshes.reserve_handle();
 

--- a/crates/bevy_landmass/README.md
+++ b/crates/bevy_landmass/README.md
@@ -45,7 +45,8 @@ fn set_up_scene(
   mut commands: Commands,
   mut nav_meshes: ResMut<Assets<NavMesh2d>>,
 ) {
-  let archipelago_id = commands.spawn(Archipelago2d::new()).id();
+  let archipelago_id =
+    commands.spawn(Archipelago2d::new(AgentOptions::default())).id();
 
   let nav_mesh_handle = nav_meshes.reserve_handle();
 

--- a/crates/bevy_landmass/example/main.rs
+++ b/crates/bevy_landmass/example/main.rs
@@ -120,7 +120,7 @@ fn setup(
     })),
   ));
 
-  let mut archipelago = Archipelago2d::new();
+  let mut archipelago = Archipelago2d::new(AgentOptions::default());
   let slow_node_type = archipelago.add_node_type(1000.0).unwrap();
   let archipelago_entity = commands.spawn(archipelago).id();
 

--- a/crates/bevy_landmass/example/main.rs
+++ b/crates/bevy_landmass/example/main.rs
@@ -120,7 +120,8 @@ fn setup(
     })),
   ));
 
-  let mut archipelago = Archipelago2d::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago2d::new(AgentOptions::default_for_agent_radius(0.5));
   let slow_node_type = archipelago.add_node_type(1000.0).unwrap();
   let archipelago_entity = commands.spawn(archipelago).id();
 

--- a/crates/bevy_landmass/src/lib.rs
+++ b/crates/bevy_landmass/src/lib.rs
@@ -48,6 +48,7 @@ pub mod prelude {
   pub use crate::Agent3dBundle;
   pub use crate::AgentDesiredVelocity2d;
   pub use crate::AgentDesiredVelocity3d;
+  pub use crate::AgentOptions;
   pub use crate::AgentSettings;
   pub use crate::AgentState;
   pub use crate::AgentTarget2d;
@@ -167,9 +168,9 @@ pub type Archipelago3d = Archipelago<ThreeD>;
 
 impl<CS: CoordinateSystem> Archipelago<CS> {
   /// Creates an empty archipelago.
-  pub fn new() -> Self {
+  pub fn new(agent_options: AgentOptions) -> Self {
     Self {
-      archipelago: landmass::Archipelago::new(),
+      archipelago: landmass::Archipelago::new(agent_options),
       islands: HashMap::new(),
       reverse_islands: HashMap::new(),
       agents: HashMap::new(),
@@ -314,12 +315,6 @@ impl<CS: CoordinateSystem> Archipelago<CS> {
       .islands
       .get(&entity)
       .and_then(|&island_id| self.archipelago.get_island_mut(island_id))
-  }
-}
-
-impl<CS: CoordinateSystem> Default for Archipelago<CS> {
-  fn default() -> Self {
-    Self::new()
   }
 }
 

--- a/crates/bevy_landmass/src/lib_test.rs
+++ b/crates/bevy_landmass/src/lib_test.rs
@@ -22,8 +22,10 @@ fn computes_path_for_agent_and_updates_desired_velocity() {
     .add_plugins(AssetPlugin::default())
     .add_plugins(Landmass3dPlugin::default());
 
-  let archipelago_id =
-    app.world_mut().spawn(Archipelago3d::new(AgentOptions::default())).id();
+  let archipelago_id = app
+    .world_mut()
+    .spawn(Archipelago3d::new(AgentOptions::default_for_agent_radius(0.5)))
+    .id();
 
   let nav_mesh = Arc::new(
     NavigationMesh3d {
@@ -109,8 +111,10 @@ fn adds_and_removes_agents() {
     .add_plugins(AssetPlugin::default())
     .add_plugins(Landmass3dPlugin::default());
 
-  let archipelago_id =
-    app.world_mut().spawn(Archipelago3d::new(AgentOptions::default())).id();
+  let archipelago_id = app
+    .world_mut()
+    .spawn(Archipelago3d::new(AgentOptions::default_for_agent_radius(0.5)))
+    .id();
 
   let agent_id_1 = app
     .world_mut()
@@ -220,8 +224,10 @@ fn adds_and_removes_characters() {
     .add_plugins(AssetPlugin::default())
     .add_plugins(Landmass3dPlugin::default());
 
-  let archipelago_id =
-    app.world_mut().spawn(Archipelago3d::new(AgentOptions::default())).id();
+  let archipelago_id = app
+    .world_mut()
+    .spawn(Archipelago3d::new(AgentOptions::default_for_agent_radius(0.5)))
+    .id();
 
   let character_id_1 = app
     .world_mut()
@@ -319,8 +325,10 @@ fn adds_and_removes_islands() {
     .add_plugins(AssetPlugin::default())
     .add_plugins(Landmass3dPlugin::default());
 
-  let archipelago_id =
-    app.world_mut().spawn(Archipelago3d::new(AgentOptions::default())).id();
+  let archipelago_id = app
+    .world_mut()
+    .spawn(Archipelago3d::new(AgentOptions::default_for_agent_radius(0.5)))
+    .id();
 
   let nav_mesh =
     app.world_mut().resource_mut::<Assets<NavMesh3d>>().add(NavMesh3d {
@@ -449,8 +457,10 @@ fn changing_agent_fields_changes_landmass_agent() {
     .add_plugins(AssetPlugin::default())
     .add_plugins(Landmass3dPlugin::default());
 
-  let archipelago =
-    app.world_mut().spawn(Archipelago3d::new(AgentOptions::default())).id();
+  let archipelago = app
+    .world_mut()
+    .spawn(Archipelago3d::new(AgentOptions::default_for_agent_radius(0.5)))
+    .id();
 
   let agent = app
     .world_mut()
@@ -535,8 +545,10 @@ fn changing_character_fields_changes_landmass_character() {
     .add_plugins(AssetPlugin::default())
     .add_plugins(Landmass3dPlugin::default());
 
-  let archipelago =
-    app.world_mut().spawn(Archipelago3d::new(AgentOptions::default())).id();
+  let archipelago = app
+    .world_mut()
+    .spawn(Archipelago3d::new(AgentOptions::default_for_agent_radius(0.5)))
+    .id();
 
   let character = app
     .world_mut()
@@ -596,7 +608,8 @@ fn node_type_costs_are_used() {
     .add_plugins(AssetPlugin::default())
     .add_plugins(Landmass2dPlugin::default());
 
-  let mut archipelago = Archipelago2d::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago2d::new(AgentOptions::default_for_agent_radius(0.5));
   let slow_node_type = archipelago.add_node_type(10.0).unwrap();
 
   let archipelago_id = app.world_mut().spawn(archipelago).id();
@@ -714,7 +727,8 @@ fn overridden_node_type_costs_are_used() {
     .add_plugins(AssetPlugin::default())
     .add_plugins(Landmass2dPlugin::default());
 
-  let mut archipelago = Archipelago2d::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago2d::new(AgentOptions::default_for_agent_radius(0.5));
   let slow_node_type = archipelago.add_node_type(1.0).unwrap();
 
   let archipelago_id = app.world_mut().spawn(archipelago).id();
@@ -837,8 +851,10 @@ fn sample_point_error_on_out_of_range() {
     .add_plugins(AssetPlugin::default())
     .add_plugins(Landmass2dPlugin::default());
 
-  let archipelago_entity =
-    app.world_mut().spawn(Archipelago2d::new(AgentOptions::default())).id();
+  let archipelago_entity = app
+    .world_mut()
+    .spawn(Archipelago2d::new(AgentOptions::default_for_agent_radius(0.5)))
+    .id();
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -890,8 +906,10 @@ fn samples_point_on_nav_mesh_or_near_nav_mesh() {
     .add_plugins(AssetPlugin::default())
     .add_plugins(Landmass2dPlugin::default());
 
-  let archipelago_entity =
-    app.world_mut().spawn(Archipelago2d::new(AgentOptions::default())).id();
+  let archipelago_entity = app
+    .world_mut()
+    .spawn(Archipelago2d::new(AgentOptions::default_for_agent_radius(0.5)))
+    .id();
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -973,7 +991,8 @@ fn samples_node_types() {
     .add_plugins(AssetPlugin::default())
     .add_plugins(Landmass2dPlugin::default());
 
-  let mut archipelago = Archipelago2d::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago2d::new(AgentOptions::default_for_agent_radius(0.5));
   let node_type = archipelago.add_node_type(2.0).unwrap();
   let archipelago_entity = app.world_mut().spawn(archipelago).id();
 
@@ -1048,8 +1067,10 @@ fn finds_path() {
     .add_plugins(AssetPlugin::default())
     .add_plugins(Landmass2dPlugin::default());
 
-  let archipelago_entity =
-    app.world_mut().spawn(Archipelago2d::new(AgentOptions::default())).id();
+  let archipelago_entity = app
+    .world_mut()
+    .spawn(Archipelago2d::new(AgentOptions::default_for_agent_radius(0.5)))
+    .id();
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -1125,8 +1146,10 @@ fn island_matches_rotation_3d() {
     .add_plugins(AssetPlugin::default())
     .add_plugins(Landmass3dPlugin::default());
 
-  let archipelago_entity =
-    app.world_mut().spawn(Archipelago3d::new(AgentOptions::default())).id();
+  let archipelago_entity = app
+    .world_mut()
+    .spawn(Archipelago3d::new(AgentOptions::default_for_agent_radius(0.5)))
+    .id();
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -1184,8 +1207,10 @@ fn island_matches_rotation_2d() {
     .add_plugins(AssetPlugin::default())
     .add_plugins(Landmass2dPlugin::default());
 
-  let archipelago_entity =
-    app.world_mut().spawn(Archipelago2d::new(AgentOptions::default())).id();
+  let archipelago_entity = app
+    .world_mut()
+    .spawn(Archipelago2d::new(AgentOptions::default_for_agent_radius(0.5)))
+    .id();
 
   let nav_mesh = Arc::new(
     NavigationMesh {

--- a/crates/bevy_landmass/src/lib_test.rs
+++ b/crates/bevy_landmass/src/lib_test.rs
@@ -5,8 +5,8 @@ use landmass::{NavigationMesh, SamplePointError};
 
 use crate::{
   Agent2dBundle, Agent3dBundle, AgentDesiredVelocity2d, AgentDesiredVelocity3d,
-  AgentNodeTypeCostOverrides, AgentSettings, AgentState, AgentTarget2d,
-  AgentTarget3d, Archipelago2d, Archipelago3d, ArchipelagoRef2d,
+  AgentNodeTypeCostOverrides, AgentOptions, AgentSettings, AgentState,
+  AgentTarget2d, AgentTarget3d, Archipelago2d, Archipelago3d, ArchipelagoRef2d,
   ArchipelagoRef3d, Character3dBundle, CharacterSettings, Island,
   Island2dBundle, Island3dBundle, Landmass2dPlugin, Landmass3dPlugin,
   NavMesh2d, NavMesh3d, NavMeshHandle, NavigationMesh3d, Velocity3d,
@@ -22,7 +22,8 @@ fn computes_path_for_agent_and_updates_desired_velocity() {
     .add_plugins(AssetPlugin::default())
     .add_plugins(Landmass3dPlugin::default());
 
-  let archipelago_id = app.world_mut().spawn(Archipelago3d::new()).id();
+  let archipelago_id =
+    app.world_mut().spawn(Archipelago3d::new(AgentOptions::default())).id();
 
   let nav_mesh = Arc::new(
     NavigationMesh3d {
@@ -108,7 +109,8 @@ fn adds_and_removes_agents() {
     .add_plugins(AssetPlugin::default())
     .add_plugins(Landmass3dPlugin::default());
 
-  let archipelago_id = app.world_mut().spawn(Archipelago3d::new()).id();
+  let archipelago_id =
+    app.world_mut().spawn(Archipelago3d::new(AgentOptions::default())).id();
 
   let agent_id_1 = app
     .world_mut()
@@ -218,7 +220,8 @@ fn adds_and_removes_characters() {
     .add_plugins(AssetPlugin::default())
     .add_plugins(Landmass3dPlugin::default());
 
-  let archipelago_id = app.world_mut().spawn(Archipelago3d::new()).id();
+  let archipelago_id =
+    app.world_mut().spawn(Archipelago3d::new(AgentOptions::default())).id();
 
   let character_id_1 = app
     .world_mut()
@@ -316,7 +319,8 @@ fn adds_and_removes_islands() {
     .add_plugins(AssetPlugin::default())
     .add_plugins(Landmass3dPlugin::default());
 
-  let archipelago_id = app.world_mut().spawn(Archipelago3d::new()).id();
+  let archipelago_id =
+    app.world_mut().spawn(Archipelago3d::new(AgentOptions::default())).id();
 
   let nav_mesh =
     app.world_mut().resource_mut::<Assets<NavMesh3d>>().add(NavMesh3d {
@@ -445,7 +449,8 @@ fn changing_agent_fields_changes_landmass_agent() {
     .add_plugins(AssetPlugin::default())
     .add_plugins(Landmass3dPlugin::default());
 
-  let archipelago = app.world_mut().spawn(Archipelago3d::new()).id();
+  let archipelago =
+    app.world_mut().spawn(Archipelago3d::new(AgentOptions::default())).id();
 
   let agent = app
     .world_mut()
@@ -530,7 +535,8 @@ fn changing_character_fields_changes_landmass_character() {
     .add_plugins(AssetPlugin::default())
     .add_plugins(Landmass3dPlugin::default());
 
-  let archipelago = app.world_mut().spawn(Archipelago3d::new()).id();
+  let archipelago =
+    app.world_mut().spawn(Archipelago3d::new(AgentOptions::default())).id();
 
   let character = app
     .world_mut()
@@ -590,7 +596,7 @@ fn node_type_costs_are_used() {
     .add_plugins(AssetPlugin::default())
     .add_plugins(Landmass2dPlugin::default());
 
-  let mut archipelago = Archipelago2d::new();
+  let mut archipelago = Archipelago2d::new(AgentOptions::default());
   let slow_node_type = archipelago.add_node_type(10.0).unwrap();
 
   let archipelago_id = app.world_mut().spawn(archipelago).id();
@@ -708,7 +714,7 @@ fn overridden_node_type_costs_are_used() {
     .add_plugins(AssetPlugin::default())
     .add_plugins(Landmass2dPlugin::default());
 
-  let mut archipelago = Archipelago2d::new();
+  let mut archipelago = Archipelago2d::new(AgentOptions::default());
   let slow_node_type = archipelago.add_node_type(1.0).unwrap();
 
   let archipelago_id = app.world_mut().spawn(archipelago).id();
@@ -831,7 +837,8 @@ fn sample_point_error_on_out_of_range() {
     .add_plugins(AssetPlugin::default())
     .add_plugins(Landmass2dPlugin::default());
 
-  let archipelago_entity = app.world_mut().spawn(Archipelago2d::new()).id();
+  let archipelago_entity =
+    app.world_mut().spawn(Archipelago2d::new(AgentOptions::default())).id();
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -883,7 +890,8 @@ fn samples_point_on_nav_mesh_or_near_nav_mesh() {
     .add_plugins(AssetPlugin::default())
     .add_plugins(Landmass2dPlugin::default());
 
-  let archipelago_entity = app.world_mut().spawn(Archipelago2d::new()).id();
+  let archipelago_entity =
+    app.world_mut().spawn(Archipelago2d::new(AgentOptions::default())).id();
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -965,7 +973,7 @@ fn samples_node_types() {
     .add_plugins(AssetPlugin::default())
     .add_plugins(Landmass2dPlugin::default());
 
-  let mut archipelago = Archipelago2d::new();
+  let mut archipelago = Archipelago2d::new(AgentOptions::default());
   let node_type = archipelago.add_node_type(2.0).unwrap();
   let archipelago_entity = app.world_mut().spawn(archipelago).id();
 
@@ -1040,7 +1048,8 @@ fn finds_path() {
     .add_plugins(AssetPlugin::default())
     .add_plugins(Landmass2dPlugin::default());
 
-  let archipelago_entity = app.world_mut().spawn(Archipelago2d::new()).id();
+  let archipelago_entity =
+    app.world_mut().spawn(Archipelago2d::new(AgentOptions::default())).id();
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -1116,7 +1125,8 @@ fn island_matches_rotation_3d() {
     .add_plugins(AssetPlugin::default())
     .add_plugins(Landmass3dPlugin::default());
 
-  let archipelago_entity = app.world_mut().spawn(Archipelago3d::new()).id();
+  let archipelago_entity =
+    app.world_mut().spawn(Archipelago3d::new(AgentOptions::default())).id();
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -1174,7 +1184,8 @@ fn island_matches_rotation_2d() {
     .add_plugins(AssetPlugin::default())
     .add_plugins(Landmass2dPlugin::default());
 
-  let archipelago_entity = app.world_mut().spawn(Archipelago2d::new()).id();
+  let archipelago_entity =
+    app.world_mut().spawn(Archipelago2d::new(AgentOptions::default())).id();
 
   let nav_mesh = Arc::new(
     NavigationMesh {

--- a/crates/landmass/README.md
+++ b/crates/landmass/README.md
@@ -54,7 +54,7 @@ use glam::Vec3;
 use landmass::*;
 use std::{sync::Arc, collections::HashMap};
 
-let mut archipelago = Archipelago::<XYZ>::new();
+let mut archipelago = Archipelago::<XYZ>::new(AgentOptions::default());
 
 let nav_mesh = NavigationMesh {
   vertices: vec![

--- a/crates/landmass/README.md
+++ b/crates/landmass/README.md
@@ -54,7 +54,8 @@ use glam::Vec3;
 use landmass::*;
 use std::{sync::Arc, collections::HashMap};
 
-let mut archipelago = Archipelago::<XYZ>::new(AgentOptions::default());
+let mut archipelago =
+  Archipelago::<XYZ>::new(AgentOptions::default_for_agent_radius(0.5));
 
 let nav_mesh = NavigationMesh {
   vertices: vec![

--- a/crates/landmass/src/agent_test.rs
+++ b/crates/landmass/src/agent_test.rs
@@ -12,7 +12,7 @@ use crate::{
   coords::{XY, XYZ},
   nav_data::NodeRef,
   path::{IslandSegment, Path, PathIndex},
-  Agent, Archipelago, Island, IslandId, NavigationMesh, NodeType,
+  Agent, AgentOptions, Archipelago, Island, IslandId, NavigationMesh, NodeType,
   TargetReachedCondition, Transform,
 };
 
@@ -93,7 +93,7 @@ fn has_reached_target_at_end_node() {
   .expect("nav mesh is valid");
   let transform =
     Transform { translation: Vec3::new(2.0, 3.0, 4.0), rotation: PI * 0.85 };
-  let mut archipelago = Archipelago::<XYZ>::new();
+  let mut archipelago = Archipelago::<XYZ>::new(AgentOptions::default());
   let island_id = archipelago.add_island(Island::new(
     transform.clone(),
     Arc::new(nav_mesh),
@@ -170,7 +170,7 @@ fn long_detour_reaches_target_in_different_ways() {
 
   let transform =
     Transform { translation: Vec3::new(2.0, 4.0, 3.0), rotation: PI * -0.85 };
-  let mut archipelago = Archipelago::<XYZ>::new();
+  let mut archipelago = Archipelago::<XYZ>::new(AgentOptions::default());
   let island_id = archipelago.add_island(Island::new(
     transform.clone(),
     Arc::new(nav_mesh),

--- a/crates/landmass/src/agent_test.rs
+++ b/crates/landmass/src/agent_test.rs
@@ -93,7 +93,8 @@ fn has_reached_target_at_end_node() {
   .expect("nav mesh is valid");
   let transform =
     Transform { translation: Vec3::new(2.0, 3.0, 4.0), rotation: PI * 0.85 };
-  let mut archipelago = Archipelago::<XYZ>::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago::<XYZ>::new(AgentOptions::default_for_agent_radius(0.5));
   let island_id = archipelago.add_island(Island::new(
     transform.clone(),
     Arc::new(nav_mesh),
@@ -170,7 +171,8 @@ fn long_detour_reaches_target_in_different_ways() {
 
   let transform =
     Transform { translation: Vec3::new(2.0, 4.0, 3.0), rotation: PI * -0.85 };
-  let mut archipelago = Archipelago::<XYZ>::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago::<XYZ>::new(AgentOptions::default_for_agent_radius(0.5));
   let island_id = archipelago.add_island(Island::new(
     transform.clone(),
     Arc::new(nav_mesh),

--- a/crates/landmass/src/avoidance_test.rs
+++ b/crates/landmass/src/avoidance_test.rs
@@ -467,7 +467,10 @@ fn applies_no_avoidance_for_far_agents() {
     /* characters= */ &HopSlotMap::with_key(),
     /* character_id_to_nav_mesh_point= */ &HashMap::new(),
     &nav_data,
-    &AgentOptions { neighbourhood: 5.0, ..Default::default() },
+    &AgentOptions {
+      neighbourhood: 5.0,
+      ..AgentOptions::default_for_agent_radius(0.5)
+    },
     /* delta_time= */ 0.01,
   );
 
@@ -556,7 +559,7 @@ fn applies_avoidance_for_two_agents() {
     &AgentOptions {
       neighbourhood: 15.0,
       avoidance_time_horizon: 15.0,
-      ..Default::default()
+      ..AgentOptions::default_for_agent_radius(0.5)
     },
     /* delta_time= */ 0.01,
   );
@@ -642,7 +645,7 @@ fn agent_avoids_character() {
     &AgentOptions {
       neighbourhood: 15.0,
       avoidance_time_horizon: 15.0,
-      ..Default::default()
+      ..AgentOptions::default_for_agent_radius(0.5)
     },
     /* delta_time= */ 0.01,
   );
@@ -715,7 +718,7 @@ fn agent_speeds_up_to_avoid_character() {
     &AgentOptions {
       neighbourhood: 15.0,
       avoidance_time_horizon: 15.0,
-      ..Default::default()
+      ..AgentOptions::default_for_agent_radius(0.5)
     },
     /* delta_time= */ 0.01,
   );
@@ -745,7 +748,7 @@ fn agent_speeds_up_to_avoid_character() {
     &AgentOptions {
       neighbourhood: 15.0,
       avoidance_time_horizon: 15.0,
-      ..Default::default()
+      ..AgentOptions::default_for_agent_radius(0.5)
     },
     /* delta_time= */ 0.01,
   );
@@ -762,7 +765,8 @@ fn agent_speeds_up_to_avoid_character() {
 
 #[test]
 fn reached_target_agent_has_different_avoidance() {
-  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago::<XY>::new(AgentOptions::default_for_agent_radius(0.5));
 
   let nav_mesh = Arc::new(
     NavigationMesh {

--- a/crates/landmass/src/avoidance_test.rs
+++ b/crates/landmass/src/avoidance_test.rs
@@ -762,7 +762,7 @@ fn agent_speeds_up_to_avoid_character() {
 
 #[test]
 fn reached_target_agent_has_different_avoidance() {
-  let mut archipelago = Archipelago::<XY>::new();
+  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
 
   let nav_mesh = Arc::new(
     NavigationMesh {

--- a/crates/landmass/src/debug_test.rs
+++ b/crates/landmass/src/debug_test.rs
@@ -5,7 +5,7 @@ use glam::Vec3;
 use crate::{
   coords::XYZ,
   debug::{DebugDrawError, DebugDrawer, LineType, PointType, TriangleType},
-  Agent, Archipelago, Island, NavigationMesh, Transform,
+  Agent, AgentOptions, Archipelago, Island, NavigationMesh, Transform,
 };
 
 use super::draw_archipelago_debug;
@@ -94,7 +94,7 @@ fn draws_island_meshes_and_agents() {
   .validate()
   .expect("Mesh is valid.");
 
-  let mut archipelago = Archipelago::<XYZ>::new();
+  let mut archipelago = Archipelago::<XYZ>::new(AgentOptions::default());
   const TRANSLATION: Vec3 = Vec3::ONE;
   archipelago.add_island(Island::new(
     Transform { translation: TRANSLATION, rotation: 0.0 },
@@ -429,7 +429,7 @@ fn draws_boundary_links() {
     .expect("The mesh is valid."),
   );
 
-  let mut archipelago = Archipelago::<XYZ>::new();
+  let mut archipelago = Archipelago::<XYZ>::new(AgentOptions::default());
   archipelago.add_island(Island::new(
     Transform::default(),
     nav_mesh.clone(),
@@ -479,7 +479,7 @@ fn fails_to_draw_dirty_archipelago() {
   let mut fake_drawer = FakeDrawer::new();
 
   // A brand new archipelago is considered clean.
-  let mut archipelago = Archipelago::<XYZ>::new();
+  let mut archipelago = Archipelago::<XYZ>::new(AgentOptions::default());
   assert_eq!(draw_archipelago_debug(&archipelago, &mut fake_drawer), Ok(()));
 
   // Creating an island marks the nav data as dirty.

--- a/crates/landmass/src/debug_test.rs
+++ b/crates/landmass/src/debug_test.rs
@@ -94,7 +94,8 @@ fn draws_island_meshes_and_agents() {
   .validate()
   .expect("Mesh is valid.");
 
-  let mut archipelago = Archipelago::<XYZ>::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago::<XYZ>::new(AgentOptions::default_for_agent_radius(0.5));
   const TRANSLATION: Vec3 = Vec3::ONE;
   archipelago.add_island(Island::new(
     Transform { translation: TRANSLATION, rotation: 0.0 },
@@ -429,7 +430,8 @@ fn draws_boundary_links() {
     .expect("The mesh is valid."),
   );
 
-  let mut archipelago = Archipelago::<XYZ>::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago::<XYZ>::new(AgentOptions::default_for_agent_radius(0.5));
   archipelago.add_island(Island::new(
     Transform::default(),
     nav_mesh.clone(),
@@ -479,7 +481,8 @@ fn fails_to_draw_dirty_archipelago() {
   let mut fake_drawer = FakeDrawer::new();
 
   // A brand new archipelago is considered clean.
-  let mut archipelago = Archipelago::<XYZ>::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago::<XYZ>::new(AgentOptions::default_for_agent_radius(0.5));
   assert_eq!(draw_archipelago_debug(&archipelago, &mut fake_drawer), Ok(()));
 
   // Creating an island marks the nav data as dirty.

--- a/crates/landmass/src/lib.rs
+++ b/crates/landmass/src/lib.rs
@@ -78,10 +78,10 @@ impl Default for AgentOptions {
 }
 
 impl<CS: CoordinateSystem> Archipelago<CS> {
-  pub fn new() -> Self {
+  pub fn new(agent_options: AgentOptions) -> Self {
     Self {
+      agent_options,
       nav_data: NavigationData::new(),
-      agent_options: AgentOptions::default(),
       agents: HopSlotMap::with_key(),
       characters: HopSlotMap::with_key(),
       pathing_results: Vec::new(),
@@ -404,12 +404,6 @@ impl<CS: CoordinateSystem> Archipelago<CS> {
       &self.agent_options,
       delta_time,
     );
-  }
-}
-
-impl<CS: CoordinateSystem> Default for Archipelago<CS> {
-  fn default() -> Self {
-    Self::new()
   }
 }
 

--- a/crates/landmass/src/lib.rs
+++ b/crates/landmass/src/lib.rs
@@ -65,11 +65,13 @@ pub struct AgentOptions {
   pub reached_destination_avoidance_responsibility: f32,
 }
 
-impl Default for AgentOptions {
-  fn default() -> Self {
+impl AgentOptions {
+  /// Creates a default set of options for a given agent radius. This is an easy
+  /// starting point for settings that can be overridden as needed.
+  pub fn default_for_agent_radius(radius: f32) -> Self {
     Self {
-      node_sample_distance: 0.1,
-      neighbourhood: 5.0,
+      node_sample_distance: 0.2 * radius,
+      neighbourhood: 10.0 * radius,
       avoidance_time_horizon: 1.0,
       obstacle_avoidance_time_horizon: 0.5,
       reached_destination_avoidance_responsibility: 0.1,

--- a/crates/landmass/src/lib_test.rs
+++ b/crates/landmass/src/lib_test.rs
@@ -4,13 +4,13 @@ use glam::{Vec2, Vec3};
 
 use crate::{
   coords::{XY, XYZ},
-  Agent, AgentId, AgentState, Archipelago, Character, CharacterId, Island,
-  IslandId, NavigationMesh, Transform,
+  Agent, AgentId, AgentOptions, AgentState, Archipelago, Character,
+  CharacterId, Island, IslandId, NavigationMesh, Transform,
 };
 
 #[test]
 fn add_and_remove_agents() {
-  let mut archipelago = Archipelago::<XYZ>::new();
+  let mut archipelago = Archipelago::<XYZ>::new(AgentOptions::default());
 
   let agent_1 = archipelago.add_agent(Agent::create(
     /* position= */ Vec3::ZERO,
@@ -83,7 +83,7 @@ fn add_and_remove_agents() {
 
 #[test]
 fn add_and_remove_characters() {
-  let mut archipelago = Archipelago::<XYZ>::new();
+  let mut archipelago = Archipelago::<XYZ>::new(AgentOptions::default());
 
   let character_1 =
     archipelago.add_character(Character { radius: 1.0, ..Default::default() });
@@ -141,7 +141,7 @@ fn add_and_remove_characters() {
 
 #[test]
 fn computes_and_follows_path() {
-  let mut archipelago = Archipelago::<XYZ>::new();
+  let mut archipelago = Archipelago::<XYZ>::new(AgentOptions::default());
   let nav_mesh = NavigationMesh {
     vertices: vec![
       Vec3::new(1.0, 1.0, 1.0),
@@ -392,7 +392,7 @@ fn computes_and_follows_path() {
 
 #[test]
 fn agent_speeds_up_to_avoid_character() {
-  let mut archipelago = Archipelago::<XY>::new();
+  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
 
   archipelago.agent_options.avoidance_time_horizon = 100.0;
   archipelago.agent_options.neighbourhood = 10.0;
@@ -457,7 +457,7 @@ fn agent_speeds_up_to_avoid_character() {
 
 #[test]
 fn add_and_remove_islands() {
-  let mut archipelago = Archipelago::<XYZ>::new();
+  let mut archipelago = Archipelago::<XYZ>::new(AgentOptions::default());
   let nav_mesh = Arc::new(
     NavigationMesh {
       vertices: vec![],
@@ -504,7 +504,7 @@ fn add_and_remove_islands() {
 
 #[test]
 fn changed_island_is_not_dirty_after_update() {
-  let mut archipelago = Archipelago::<XYZ>::new();
+  let mut archipelago = Archipelago::<XYZ>::new(AgentOptions::default());
 
   let island_id = archipelago.add_island(Island::new(
     Transform::default(),
@@ -540,7 +540,7 @@ fn changed_island_is_not_dirty_after_update() {
 
 #[test]
 fn samples_point() {
-  let mut archipelago = Archipelago::<XY>::new();
+  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -596,7 +596,7 @@ fn samples_point() {
 
 #[test]
 fn finds_path() {
-  let mut archipelago = Archipelago::<XY>::new();
+  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -649,7 +649,7 @@ fn finds_path() {
 
 #[test]
 fn agent_overrides_node_costs() {
-  let mut archipelago = Archipelago::<XY>::new();
+  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
 
   let nav_mesh = Arc::new(
     NavigationMesh {

--- a/crates/landmass/src/lib_test.rs
+++ b/crates/landmass/src/lib_test.rs
@@ -10,7 +10,8 @@ use crate::{
 
 #[test]
 fn add_and_remove_agents() {
-  let mut archipelago = Archipelago::<XYZ>::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago::<XYZ>::new(AgentOptions::default_for_agent_radius(0.5));
 
   let agent_1 = archipelago.add_agent(Agent::create(
     /* position= */ Vec3::ZERO,
@@ -83,7 +84,8 @@ fn add_and_remove_agents() {
 
 #[test]
 fn add_and_remove_characters() {
-  let mut archipelago = Archipelago::<XYZ>::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago::<XYZ>::new(AgentOptions::default_for_agent_radius(0.5));
 
   let character_1 =
     archipelago.add_character(Character { radius: 1.0, ..Default::default() });
@@ -141,7 +143,8 @@ fn add_and_remove_characters() {
 
 #[test]
 fn computes_and_follows_path() {
-  let mut archipelago = Archipelago::<XYZ>::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago::<XYZ>::new(AgentOptions::default_for_agent_radius(0.5));
   let nav_mesh = NavigationMesh {
     vertices: vec![
       Vec3::new(1.0, 1.0, 1.0),
@@ -392,7 +395,8 @@ fn computes_and_follows_path() {
 
 #[test]
 fn agent_speeds_up_to_avoid_character() {
-  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago::<XY>::new(AgentOptions::default_for_agent_radius(0.5));
 
   archipelago.agent_options.avoidance_time_horizon = 100.0;
   archipelago.agent_options.neighbourhood = 10.0;
@@ -457,7 +461,8 @@ fn agent_speeds_up_to_avoid_character() {
 
 #[test]
 fn add_and_remove_islands() {
-  let mut archipelago = Archipelago::<XYZ>::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago::<XYZ>::new(AgentOptions::default_for_agent_radius(0.5));
   let nav_mesh = Arc::new(
     NavigationMesh {
       vertices: vec![],
@@ -504,7 +509,8 @@ fn add_and_remove_islands() {
 
 #[test]
 fn changed_island_is_not_dirty_after_update() {
-  let mut archipelago = Archipelago::<XYZ>::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago::<XYZ>::new(AgentOptions::default_for_agent_radius(0.5));
 
   let island_id = archipelago.add_island(Island::new(
     Transform::default(),
@@ -540,7 +546,8 @@ fn changed_island_is_not_dirty_after_update() {
 
 #[test]
 fn samples_point() {
-  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago::<XY>::new(AgentOptions::default_for_agent_radius(0.5));
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -596,7 +603,8 @@ fn samples_point() {
 
 #[test]
 fn finds_path() {
-  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago::<XY>::new(AgentOptions::default_for_agent_radius(0.5));
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -649,7 +657,8 @@ fn finds_path() {
 
 #[test]
 fn agent_overrides_node_costs() {
-  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago::<XY>::new(AgentOptions::default_for_agent_radius(0.5));
 
   let nav_mesh = Arc::new(
     NavigationMesh {

--- a/crates/landmass/src/nav_data_test.rs
+++ b/crates/landmass/src/nav_data_test.rs
@@ -964,7 +964,8 @@ fn empty_navigation_mesh_is_safe() {
 
 #[test]
 fn error_on_create_zero_or_negative_node_type() {
-  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago::<XY>::new(AgentOptions::default_for_agent_radius(0.5));
   assert_eq!(
     archipelago.add_node_type(0.0),
     Err(NewNodeTypeError::NonPositiveCost(0.0))
@@ -977,7 +978,8 @@ fn error_on_create_zero_or_negative_node_type() {
 
 #[test]
 fn false_on_setting_zero_or_negative_node_type() {
-  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago::<XY>::new(AgentOptions::default_for_agent_radius(0.5));
 
   let node_type = archipelago.add_node_type(1.0).unwrap();
 
@@ -993,7 +995,8 @@ fn false_on_setting_zero_or_negative_node_type() {
 
 #[test]
 fn cannot_remove_used_node_type() {
-  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago::<XY>::new(AgentOptions::default_for_agent_radius(0.5));
 
   let node_type_1 = archipelago.add_node_type(2.0).unwrap();
   let node_type_2 = archipelago.add_node_type(3.0).unwrap();
@@ -1068,7 +1071,8 @@ fn cannot_remove_used_node_type() {
 #[test]
 #[should_panic]
 fn panics_on_invalid_node_type() {
-  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago::<XY>::new(AgentOptions::default_for_agent_radius(0.5));
   let deleted_node_type = archipelago.add_node_type(2.0).unwrap();
   assert!(archipelago.remove_node_type(deleted_node_type));
 

--- a/crates/landmass/src/nav_data_test.rs
+++ b/crates/landmass/src/nav_data_test.rs
@@ -13,8 +13,8 @@ use crate::{
   island::Island,
   nav_data::{BoundaryLink, NodeRef},
   nav_mesh::NavigationMesh,
-  Archipelago, IslandId, NewNodeTypeError, NodeType, SetNodeTypeCostError,
-  Transform,
+  AgentOptions, Archipelago, IslandId, NewNodeTypeError, NodeType,
+  SetNodeTypeCostError, Transform,
 };
 
 use super::{
@@ -964,7 +964,7 @@ fn empty_navigation_mesh_is_safe() {
 
 #[test]
 fn error_on_create_zero_or_negative_node_type() {
-  let mut archipelago = Archipelago::<XY>::new();
+  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
   assert_eq!(
     archipelago.add_node_type(0.0),
     Err(NewNodeTypeError::NonPositiveCost(0.0))
@@ -977,7 +977,7 @@ fn error_on_create_zero_or_negative_node_type() {
 
 #[test]
 fn false_on_setting_zero_or_negative_node_type() {
-  let mut archipelago = Archipelago::<XY>::new();
+  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
 
   let node_type = archipelago.add_node_type(1.0).unwrap();
 
@@ -993,7 +993,7 @@ fn false_on_setting_zero_or_negative_node_type() {
 
 #[test]
 fn cannot_remove_used_node_type() {
-  let mut archipelago = Archipelago::<XY>::new();
+  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
 
   let node_type_1 = archipelago.add_node_type(2.0).unwrap();
   let node_type_2 = archipelago.add_node_type(3.0).unwrap();
@@ -1068,7 +1068,7 @@ fn cannot_remove_used_node_type() {
 #[test]
 #[should_panic]
 fn panics_on_invalid_node_type() {
-  let mut archipelago = Archipelago::<XY>::new();
+  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
   let deleted_node_type = archipelago.add_node_type(2.0).unwrap();
   assert!(archipelago.remove_node_type(deleted_node_type));
 

--- a/crates/landmass/src/path_test.rs
+++ b/crates/landmass/src/path_test.rs
@@ -12,7 +12,7 @@ use crate::{
   nav_data::{BoundaryLinkId, NavigationData, NodeRef},
   nav_mesh::NavigationMesh,
   path::{BoundaryLinkSegment, IslandSegment},
-  Archipelago, CoordinateSystem, Island, IslandId, Transform,
+  AgentOptions, Archipelago, CoordinateSystem, Island, IslandId, Transform,
 };
 
 use super::{Path, PathIndex};
@@ -72,7 +72,7 @@ fn finds_next_point_for_organic_map() {
 
   let transform =
     Transform { translation: Vec3::new(5.0, 9.0, 7.0), rotation: PI * -0.35 };
-  let mut archipelago = Archipelago::<XYZ>::new();
+  let mut archipelago = Archipelago::<XYZ>::new(AgentOptions::default());
   let island_id = archipelago.add_island(Island::new(
     transform.clone(),
     Arc::new(nav_mesh),
@@ -178,7 +178,7 @@ fn finds_next_point_in_zig_zag() {
 
   let transform =
     Transform { translation: Vec2::new(-1.0, -3.0), rotation: PI * -1.8 };
-  let mut archipelago = Archipelago::<XY>::new();
+  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
   let island_id = archipelago.add_island(Island::new(
     transform.clone(),
     Arc::new(nav_mesh),
@@ -252,7 +252,7 @@ fn starts_at_end_index_goes_to_end_point() {
   .validate()
   .expect("Mesh is valid.");
 
-  let mut archipelago = Archipelago::<XYZ>::new();
+  let mut archipelago = Archipelago::<XYZ>::new(AgentOptions::default());
   let island_id = archipelago.add_island(Island::new(
     Transform { translation: Vec3::ZERO, rotation: 0.0 },
     Arc::new(nav_mesh),

--- a/crates/landmass/src/path_test.rs
+++ b/crates/landmass/src/path_test.rs
@@ -72,7 +72,8 @@ fn finds_next_point_for_organic_map() {
 
   let transform =
     Transform { translation: Vec3::new(5.0, 9.0, 7.0), rotation: PI * -0.35 };
-  let mut archipelago = Archipelago::<XYZ>::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago::<XYZ>::new(AgentOptions::default_for_agent_radius(0.5));
   let island_id = archipelago.add_island(Island::new(
     transform.clone(),
     Arc::new(nav_mesh),
@@ -178,7 +179,8 @@ fn finds_next_point_in_zig_zag() {
 
   let transform =
     Transform { translation: Vec2::new(-1.0, -3.0), rotation: PI * -1.8 };
-  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago::<XY>::new(AgentOptions::default_for_agent_radius(0.5));
   let island_id = archipelago.add_island(Island::new(
     transform.clone(),
     Arc::new(nav_mesh),
@@ -252,7 +254,8 @@ fn starts_at_end_index_goes_to_end_point() {
   .validate()
   .expect("Mesh is valid.");
 
-  let mut archipelago = Archipelago::<XYZ>::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago::<XYZ>::new(AgentOptions::default_for_agent_radius(0.5));
   let island_id = archipelago.add_island(Island::new(
     Transform { translation: Vec3::ZERO, rotation: 0.0 },
     Arc::new(nav_mesh),

--- a/crates/landmass/src/pathfinding_test.rs
+++ b/crates/landmass/src/pathfinding_test.rs
@@ -7,7 +7,7 @@ use crate::{
   nav_data::NodeRef,
   nav_mesh::NavigationMesh,
   path::{BoundaryLinkSegment, IslandSegment, Path},
-  Archipelago, Island, Transform,
+  AgentOptions, Archipelago, Island, Transform,
 };
 
 use super::find_path;
@@ -43,7 +43,7 @@ fn finds_path_in_archipelago() {
   .validate()
   .expect("Mesh is valid.");
 
-  let mut archipelago = Archipelago::<XYZ>::new();
+  let mut archipelago = Archipelago::<XYZ>::new(AgentOptions::default());
   let island_id = archipelago.add_island(Island::new(
     Transform { translation: Vec3::ZERO, rotation: 0.0 },
     Arc::new(nav_mesh),
@@ -142,7 +142,7 @@ fn finds_paths_on_two_islands() {
   .expect("Mesh is valid.");
   let nav_mesh = Arc::new(nav_mesh);
 
-  let mut archipelago = Archipelago::<XYZ>::new();
+  let mut archipelago = Archipelago::<XYZ>::new(AgentOptions::default());
   let island_id_1 = archipelago.add_island(Island::new(
     Transform { translation: Vec3::ZERO, rotation: 0.0 },
     Arc::clone(&nav_mesh),
@@ -228,7 +228,7 @@ fn no_path_between_disconnected_islands() {
   .expect("Mesh is valid.");
   let nav_mesh = Arc::new(nav_mesh);
 
-  let mut archipelago = Archipelago::<XYZ>::new();
+  let mut archipelago = Archipelago::<XYZ>::new(AgentOptions::default());
   let island_id_1 = archipelago.add_island(Island::new(
     Transform { translation: Vec3::ZERO, rotation: 0.0 },
     Arc::clone(&nav_mesh),
@@ -279,7 +279,7 @@ fn find_path_across_connected_islands() {
     .expect("Mesh is valid."),
   );
 
-  let mut archipelago = Archipelago::<XYZ>::new();
+  let mut archipelago = Archipelago::<XYZ>::new(AgentOptions::default());
 
   let island_id_1 = archipelago.add_island(Island::new(
     Transform { rotation: 0.0, translation: Vec3::ZERO },
@@ -405,7 +405,7 @@ fn finds_path_across_different_islands() {
     .expect("Mesh is valid."),
   );
 
-  let mut archipelago = Archipelago::<XYZ>::new();
+  let mut archipelago = Archipelago::<XYZ>::new(AgentOptions::default());
 
   let island_id_1 = archipelago.add_island(Island::new(
     Transform { rotation: 0.0, translation: Vec3::ZERO },
@@ -479,7 +479,7 @@ fn aborts_early_for_unconnected_regions() {
     .expect("Mesh is valid."),
   );
 
-  let mut archipelago = Archipelago::<XYZ>::new();
+  let mut archipelago = Archipelago::<XYZ>::new(AgentOptions::default());
 
   let island_id_1 = archipelago.add_island(Island::new(
     Transform { translation: Vec3::ZERO, rotation: 0.0 },
@@ -527,7 +527,7 @@ fn aborts_early_for_unconnected_regions() {
 
 #[test]
 fn detour_for_high_cost_path() {
-  let mut archipelago = Archipelago::<XY>::new();
+  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -605,7 +605,7 @@ fn detour_for_high_cost_path() {
 
 #[test]
 fn detour_for_high_cost_path_across_boundary_links() {
-  let mut archipelago = Archipelago::<XY>::new();
+  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
 
   let nav_mesh_1 = Arc::new(
     NavigationMesh {
@@ -713,7 +713,7 @@ fn detour_for_high_cost_path_across_boundary_links() {
 
 #[test]
 fn fast_path_not_ignored_by_heuristic() {
-  let mut archipelago = Archipelago::<XY>::new();
+  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -793,7 +793,7 @@ fn fast_path_not_ignored_by_heuristic() {
 
 #[test]
 fn infinite_or_nan_cost_cannot_find_path() {
-  let mut archipelago = Archipelago::<XY>::new();
+  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -847,7 +847,7 @@ fn infinite_or_nan_cost_cannot_find_path() {
 
 #[test]
 fn detour_for_overridden_high_cost_path() {
-  let mut archipelago = Archipelago::<XY>::new();
+  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
 
   let nav_mesh = Arc::new(
     NavigationMesh {

--- a/crates/landmass/src/pathfinding_test.rs
+++ b/crates/landmass/src/pathfinding_test.rs
@@ -43,7 +43,8 @@ fn finds_path_in_archipelago() {
   .validate()
   .expect("Mesh is valid.");
 
-  let mut archipelago = Archipelago::<XYZ>::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago::<XYZ>::new(AgentOptions::default_for_agent_radius(0.5));
   let island_id = archipelago.add_island(Island::new(
     Transform { translation: Vec3::ZERO, rotation: 0.0 },
     Arc::new(nav_mesh),
@@ -142,7 +143,8 @@ fn finds_paths_on_two_islands() {
   .expect("Mesh is valid.");
   let nav_mesh = Arc::new(nav_mesh);
 
-  let mut archipelago = Archipelago::<XYZ>::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago::<XYZ>::new(AgentOptions::default_for_agent_radius(0.5));
   let island_id_1 = archipelago.add_island(Island::new(
     Transform { translation: Vec3::ZERO, rotation: 0.0 },
     Arc::clone(&nav_mesh),
@@ -228,7 +230,8 @@ fn no_path_between_disconnected_islands() {
   .expect("Mesh is valid.");
   let nav_mesh = Arc::new(nav_mesh);
 
-  let mut archipelago = Archipelago::<XYZ>::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago::<XYZ>::new(AgentOptions::default_for_agent_radius(0.5));
   let island_id_1 = archipelago.add_island(Island::new(
     Transform { translation: Vec3::ZERO, rotation: 0.0 },
     Arc::clone(&nav_mesh),
@@ -279,7 +282,8 @@ fn find_path_across_connected_islands() {
     .expect("Mesh is valid."),
   );
 
-  let mut archipelago = Archipelago::<XYZ>::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago::<XYZ>::new(AgentOptions::default_for_agent_radius(0.5));
 
   let island_id_1 = archipelago.add_island(Island::new(
     Transform { rotation: 0.0, translation: Vec3::ZERO },
@@ -405,7 +409,8 @@ fn finds_path_across_different_islands() {
     .expect("Mesh is valid."),
   );
 
-  let mut archipelago = Archipelago::<XYZ>::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago::<XYZ>::new(AgentOptions::default_for_agent_radius(0.5));
 
   let island_id_1 = archipelago.add_island(Island::new(
     Transform { rotation: 0.0, translation: Vec3::ZERO },
@@ -479,7 +484,8 @@ fn aborts_early_for_unconnected_regions() {
     .expect("Mesh is valid."),
   );
 
-  let mut archipelago = Archipelago::<XYZ>::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago::<XYZ>::new(AgentOptions::default_for_agent_radius(0.5));
 
   let island_id_1 = archipelago.add_island(Island::new(
     Transform { translation: Vec3::ZERO, rotation: 0.0 },
@@ -527,7 +533,8 @@ fn aborts_early_for_unconnected_regions() {
 
 #[test]
 fn detour_for_high_cost_path() {
-  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago::<XY>::new(AgentOptions::default_for_agent_radius(0.5));
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -605,7 +612,8 @@ fn detour_for_high_cost_path() {
 
 #[test]
 fn detour_for_high_cost_path_across_boundary_links() {
-  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago::<XY>::new(AgentOptions::default_for_agent_radius(0.5));
 
   let nav_mesh_1 = Arc::new(
     NavigationMesh {
@@ -713,7 +721,8 @@ fn detour_for_high_cost_path_across_boundary_links() {
 
 #[test]
 fn fast_path_not_ignored_by_heuristic() {
-  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago::<XY>::new(AgentOptions::default_for_agent_radius(0.5));
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -793,7 +802,8 @@ fn fast_path_not_ignored_by_heuristic() {
 
 #[test]
 fn infinite_or_nan_cost_cannot_find_path() {
-  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago::<XY>::new(AgentOptions::default_for_agent_radius(0.5));
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -847,7 +857,8 @@ fn infinite_or_nan_cost_cannot_find_path() {
 
 #[test]
 fn detour_for_overridden_high_cost_path() {
-  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago::<XY>::new(AgentOptions::default_for_agent_radius(0.5));
 
   let nav_mesh = Arc::new(
     NavigationMesh {

--- a/crates/landmass/src/query_test.rs
+++ b/crates/landmass/src/query_test.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, sync::Arc};
 use glam::Vec2;
 
 use crate::{
-  coords::XY, Archipelago, FindPathError, Island, NavigationMesh,
+  coords::XY, AgentOptions, Archipelago, FindPathError, Island, NavigationMesh,
   SamplePointError, Transform,
 };
 
@@ -11,7 +11,7 @@ use super::{find_path, sample_point};
 
 #[test]
 fn error_on_dirty_nav_mesh() {
-  let mut archipelago = Archipelago::<XY>::new();
+  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -46,7 +46,7 @@ fn error_on_dirty_nav_mesh() {
 
 #[test]
 fn error_on_out_of_range() {
-  let mut archipelago = Archipelago::<XY>::new();
+  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -83,7 +83,7 @@ fn error_on_out_of_range() {
 
 #[test]
 fn samples_point_on_nav_mesh_or_near_nav_mesh() {
-  let mut archipelago = Archipelago::<XY>::new();
+  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -139,7 +139,7 @@ fn samples_point_on_nav_mesh_or_near_nav_mesh() {
 
 #[test]
 fn samples_node_types() {
-  let mut archipelago = Archipelago::<XY>::new();
+  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
 
   let node_type_1 = archipelago.add_node_type(1.0).unwrap();
   let node_type_2 = archipelago.add_node_type(2.0).unwrap();
@@ -219,7 +219,7 @@ fn samples_node_types() {
 
 #[test]
 fn no_path() {
-  let mut archipelago = Archipelago::<XY>::new();
+  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -263,7 +263,7 @@ fn no_path() {
 
 #[test]
 fn finds_path() {
-  let mut archipelago = Archipelago::<XY>::new();
+  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -316,7 +316,7 @@ fn finds_path() {
 
 #[test]
 fn finds_path_with_override_node_types() {
-  let mut archipelago = Archipelago::<XY>::new();
+  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -407,7 +407,7 @@ fn finds_path_with_override_node_types() {
 
 #[test]
 fn find_path_returns_error_on_invalid_node_cost() {
-  let mut archipelago = Archipelago::<XY>::new();
+  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
 
   let nav_mesh = Arc::new(
     NavigationMesh {

--- a/crates/landmass/src/query_test.rs
+++ b/crates/landmass/src/query_test.rs
@@ -11,7 +11,8 @@ use super::{find_path, sample_point};
 
 #[test]
 fn error_on_dirty_nav_mesh() {
-  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago::<XY>::new(AgentOptions::default_for_agent_radius(0.5));
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -46,7 +47,8 @@ fn error_on_dirty_nav_mesh() {
 
 #[test]
 fn error_on_out_of_range() {
-  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago::<XY>::new(AgentOptions::default_for_agent_radius(0.5));
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -83,7 +85,8 @@ fn error_on_out_of_range() {
 
 #[test]
 fn samples_point_on_nav_mesh_or_near_nav_mesh() {
-  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago::<XY>::new(AgentOptions::default_for_agent_radius(0.5));
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -139,7 +142,8 @@ fn samples_point_on_nav_mesh_or_near_nav_mesh() {
 
 #[test]
 fn samples_node_types() {
-  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago::<XY>::new(AgentOptions::default_for_agent_radius(0.5));
 
   let node_type_1 = archipelago.add_node_type(1.0).unwrap();
   let node_type_2 = archipelago.add_node_type(2.0).unwrap();
@@ -219,7 +223,8 @@ fn samples_node_types() {
 
 #[test]
 fn no_path() {
-  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago::<XY>::new(AgentOptions::default_for_agent_radius(0.5));
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -263,7 +268,8 @@ fn no_path() {
 
 #[test]
 fn finds_path() {
-  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago::<XY>::new(AgentOptions::default_for_agent_radius(0.5));
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -316,7 +322,8 @@ fn finds_path() {
 
 #[test]
 fn finds_path_with_override_node_types() {
-  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago::<XY>::new(AgentOptions::default_for_agent_radius(0.5));
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -407,7 +414,8 @@ fn finds_path_with_override_node_types() {
 
 #[test]
 fn find_path_returns_error_on_invalid_node_cost() {
-  let mut archipelago = Archipelago::<XY>::new(AgentOptions::default());
+  let mut archipelago =
+    Archipelago::<XY>::new(AgentOptions::default_for_agent_radius(0.5));
 
   let nav_mesh = Arc::new(
     NavigationMesh {


### PR DESCRIPTION
Previously, the `AgentOptions` were arbitrary defaults. The is unfortunate for cases where agents don't have a radius near 1. For example, in 2D cases, agents may be ~100px in size. This makes the default neighbourhood 5px, which results in very strange behaviour. Now, users have to explicitly pass in the `AgentOptions`, and there is no default, only a default constructor that takes in the agent's radius.