### PR TITLE
Add a way to visualize `dodgy_2d` avoidance data for agents.

### DIFF
--- a/crates/bevy_landmass/Cargo.toml
+++ b/crates/bevy_landmass/Cargo.toml
@@ -27,10 +27,12 @@ landmass = { path = "../landmass", version = "0.8.0-dev" }
 
 [dev-dependencies]
 bevy = "0.15.0"
+googletest = "0.13.0"
 
 [features]
 default = ["mesh-utils"]
 mesh-utils = ["bevy/bevy_render"]
+debug-avoidance = ["landmass/debug-avoidance"]
 
 [[example]]
 name = "bevy_landmass_example"

--- a/crates/bevy_landmass/src/debug_test.rs
+++ b/crates/bevy_landmass/src/debug_test.rs
@@ -212,3 +212,205 @@ fn draws_archipelago_debug() {
     ]
   );
 }
+
+#[cfg(feature = "debug-avoidance")]
+#[googletest::gtest]
+fn draws_avoidance_data_when_requested() {
+  use std::collections::HashMap;
+
+  use crate::{
+    debug::{
+      draw_avoidance_data, AvoidanceDrawer, ConstraintKind, ConstraintLine,
+    },
+    AgentTarget3d, KeepAvoidanceData, NavigationMesh, Velocity3d,
+  };
+
+  use bevy::{math::Vec2, prelude::Entity};
+  use googletest::{matcher::MatcherResult, prelude::*};
+
+  let mut app = App::new();
+
+  app
+    .add_plugins(MinimalPlugins)
+    .add_plugins(TransformPlugin)
+    .add_plugins(AssetPlugin::default())
+    .add_plugins(Landmass3dPlugin::default());
+  // Update early to allow the time to not be 0.0.
+  app.update();
+
+  let archipelago_id = app
+    .world_mut()
+    .spawn(Archipelago3d::new(AgentOptions {
+      neighbourhood: 100.0,
+      avoidance_time_horizon: 100.0,
+      obstacle_avoidance_time_horizon: 100.0,
+      ..AgentOptions::default_for_agent_radius(0.5)
+    }))
+    .id();
+
+  let nav_mesh = Arc::new(
+    NavigationMesh {
+      vertices: vec![
+        Vec3::new(1.0, 1.0, 1.0),
+        Vec3::new(11.0, 1.0, 1.0),
+        Vec3::new(11.0, 1.0, 11.0),
+        Vec3::new(1.0, 1.0, 11.0),
+      ],
+      polygons: vec![vec![3, 2, 1, 0]],
+      polygon_type_indices: vec![0],
+    }
+    .validate()
+    .expect("The mesh is valid."),
+  );
+
+  let nav_mesh_handle = app
+    .world_mut()
+    .resource_mut::<Assets<NavMesh3d>>()
+    .add(NavMesh3d { nav_mesh, type_index_to_node_type: Default::default() });
+
+  app.world_mut().spawn((Island3dBundle {
+    island: Island,
+    archipelago_ref: ArchipelagoRef3d::new(archipelago_id),
+    nav_mesh: NavMeshHandle(nav_mesh_handle.clone()),
+  },));
+
+  let agent_1 = app
+    .world_mut()
+    .spawn((
+      Transform::from_translation(Vec3::new(6.0, 1.0, 2.0)),
+      Agent3dBundle {
+        agent: Agent::default(),
+        archipelago_ref: ArchipelagoRef3d::new(archipelago_id),
+        settings: AgentSettings {
+          radius: 0.5,
+          max_speed: 1.0,
+          desired_speed: 1.0,
+        },
+      },
+      Velocity3d {
+        // Use a velocity that allows both agents to agree on their "passing
+        // side".
+        velocity: Vec3::new(1.0, 0.0, 1.0),
+      },
+      AgentTarget3d::Point(Vec3::new(6.0, 1.0, 10.0)),
+      KeepAvoidanceData,
+    ))
+    .id();
+
+  app.world_mut().spawn((
+    Transform::from_translation(Vec3::new(6.0, 1.0, 10.0)),
+    Agent3dBundle {
+      agent: Agent::default(),
+      archipelago_ref: ArchipelagoRef3d::new(archipelago_id),
+      settings: AgentSettings {
+        radius: 0.5,
+        max_speed: 1.0,
+        desired_speed: 1.0,
+      },
+    },
+    AgentTarget3d::Point(Vec3::new(6.0, 1.0, 2.0)),
+  ));
+
+  // We now have avoidance data for agent_1.
+  app.update();
+
+  struct FakeAvoidanceDrawer(
+    HashMap<Entity, HashMap<ConstraintKind, Vec<ConstraintLine>>>,
+  );
+
+  impl AvoidanceDrawer for FakeAvoidanceDrawer {
+    fn add_constraint(
+      &mut self,
+      agent: Entity,
+      constraint: ConstraintLine,
+      kind: ConstraintKind,
+    ) {
+      self
+        .0
+        .entry(agent)
+        .or_default()
+        .entry(kind)
+        .or_default()
+        .push(constraint);
+    }
+  }
+
+  let mut drawer = FakeAvoidanceDrawer(Default::default());
+
+  let archipelago =
+    app.world().entity(archipelago_id).get::<Archipelago3d>().unwrap();
+
+  draw_avoidance_data(archipelago, &mut drawer);
+
+  #[derive(MatcherBase)]
+  struct EquivLineMatcher(ConstraintLine);
+
+  impl Matcher<&ConstraintLine> for EquivLineMatcher {
+    fn matches(&self, actual: &ConstraintLine) -> MatcherResult {
+      if self.0.normal.angle_to(actual.normal).abs() >= 1e-3 {
+        // The lines don't point in the same direction.
+        return MatcherResult::NoMatch;
+      }
+      if (self.0.point - actual.point).dot(actual.normal).abs() >= 1e-3 {
+        // The expected line point is not on the actual line.
+        return MatcherResult::NoMatch;
+      }
+      MatcherResult::Match
+    }
+
+    fn describe(
+      &self,
+      matcher_result: MatcherResult,
+    ) -> googletest::description::Description {
+      match matcher_result {
+        MatcherResult::Match => {
+          format!("is equivalent to the line {:?}", self.0).into()
+        }
+        MatcherResult::NoMatch => {
+          format!("isn't equivalent to the line {:?}", self.0).into()
+        }
+      }
+    }
+  }
+
+  fn equiv_line<'a>(line: ConstraintLine) -> impl Matcher<&'a ConstraintLine> {
+    EquivLineMatcher(line)
+  }
+
+  // I would ideally use three levels of unordered_elements_are here instead,
+  // but due to https://github.com/rust-lang/rust/issues/134719
+  expect_eq!(drawer.0.len(), 1);
+  let agent_constraints = drawer.0.get(&agent_1).unwrap();
+  expect_eq!(agent_constraints.len(), 1);
+  let agent_constraints =
+    agent_constraints.get(&ConstraintKind::Original).unwrap();
+
+  // Only one of the agents was rendered.
+  expect_that!(
+    agent_constraints,
+    unordered_elements_are!(
+      // Lines for the edges of the nav mesh.
+      equiv_line(ConstraintLine {
+        normal: Vec2::new(-1.0, 0.0),
+        point: Vec2::new(0.05, 0.0),
+      }),
+      equiv_line(ConstraintLine {
+        normal: Vec2::new(0.0, 1.0),
+        point: Vec2::new(0.0, -0.09),
+      }),
+      equiv_line(ConstraintLine {
+        normal: Vec2::new(1.0, 0.0),
+        point: Vec2::new(-0.05, 0.0),
+      }),
+      equiv_line(ConstraintLine {
+        normal: Vec2::new(0.0, -1.0),
+        point: Vec2::new(0.0, 0.01),
+      }),
+      // Line for the other agent.
+      equiv_line(ConstraintLine {
+        normal: Vec2::new(1.007905, -8.0).normalize().perp(),
+        point: Vec2::new(0.0, 0.0),
+      }),
+    )
+  );
+}

--- a/crates/bevy_landmass/src/lib_test.rs
+++ b/crates/bevy_landmass/src/lib_test.rs
@@ -526,6 +526,8 @@ fn changing_agent_fields_changes_landmass_agent() {
     panic!("Expected distance reached condition");
   };
   assert_eq!(dist, Some(1.0));
+  #[cfg(feature = "debug-avoidance")]
+  assert_eq!(agent_ref.keep_avoidance_data, false);
 
   app.world_mut().entity_mut(agent).insert((
     Transform::from_translation(Vec3::new(7.0, 8.0, 9.0)),
@@ -533,6 +535,8 @@ fn changing_agent_fields_changes_landmass_agent() {
     Velocity3d { velocity: Vec3::new(10.0, 11.0, 12.0) },
     AgentTarget3d::Point(Vec3::new(13.0, 14.0, 15.0)),
     crate::TargetReachedCondition::VisibleAtDistance(Some(2.0)),
+    #[cfg(feature = "debug-avoidance")]
+    crate::KeepAvoidanceData,
   ));
 
   app.update();
@@ -555,6 +559,8 @@ fn changing_agent_fields_changes_landmass_agent() {
     panic!("Expected distance reached condition");
   };
   assert_eq!(dist, Some(2.0));
+  #[cfg(feature = "debug-avoidance")]
+  assert_eq!(agent_ref.keep_avoidance_data, true);
 }
 
 #[test]

--- a/crates/landmass/Cargo.toml
+++ b/crates/landmass/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["game-development"]
 keywords = ["navigation", "system", "pathfinding", "avoidance"]
 
 [dependencies]
-dodgy_2d = "0.5.1"
+dodgy_2d = "0.5.4"
 glam = "0.29.1"
 kdtree = "0.7.0"
 ord_subset = "3.1.1"
@@ -22,3 +22,7 @@ geo = "0.29.1"
 disjoint = "0.8.0"
 slotmap = "1.0.7"
 thiserror = "1.0"
+
+[features]
+# Allows you to access avoidance data for an agent when debugging.
+debug-avoidance = ["dodgy_2d/debug"]

--- a/crates/landmass/Cargo.toml
+++ b/crates/landmass/Cargo.toml
@@ -23,6 +23,9 @@ disjoint = "0.8.0"
 slotmap = "1.0.7"
 thiserror = "1.0"
 
+[dev-dependencies]
+googletest = "0.13.0"
+
 [features]
 # Allows you to access avoidance data for an agent when debugging.
 debug-avoidance = ["dodgy_2d/debug"]

--- a/crates/landmass/src/agent.rs
+++ b/crates/landmass/src/agent.rs
@@ -54,6 +54,10 @@ pub struct Agent<CS: CoordinateSystem> {
   pub current_target: Option<CS::Coordinate>,
   /// The condition to test for reaching the target.
   pub target_reached_condition: TargetReachedCondition,
+  #[cfg(feature = "debug-avoidance")]
+  /// If true, avoidance debug data will be stored during update iterations.
+  /// This can later be used for visualization.
+  pub keep_avoidance_data: bool,
   /// Overrides for the "default" costs of each [`NodeType`].
   pub(crate) override_node_type_to_cost: HashMap<NodeType, f32>,
   /// The current path of the agent. None if a path is unavailable or a new
@@ -63,6 +67,10 @@ pub struct Agent<CS: CoordinateSystem> {
   pub(crate) current_desired_move: CS::Coordinate,
   /// The state of the agent.
   pub(crate) state: AgentState,
+  #[cfg(feature = "debug-avoidance")]
+  /// The avoidance data from the most recent update iteration. Only populated
+  /// if [`Self::keep_avoidance_data`] is true.
+  pub(crate) avoidance_data: Option<dodgy_2d::debug::DebugData>,
 }
 
 /// The condition to consider the agent as having reached its target. When this
@@ -117,10 +125,14 @@ impl<CS: CoordinateSystem> Agent<CS> {
       max_speed,
       current_target: None,
       target_reached_condition: TargetReachedCondition::Distance(None),
+      #[cfg(feature = "debug-avoidance")]
+      keep_avoidance_data: false,
       override_node_type_to_cost: HashMap::new(),
       current_path: None,
       current_desired_move: CS::from_landmass(&Vec3::ZERO),
       state: AgentState::Idle,
+      #[cfg(feature = "debug-avoidance")]
+      avoidance_data: None,
     }
   }
 


### PR DESCRIPTION
This gives more visualization tools for `landmass` and `bevy_landmass`.