### PR TITLE
Make the schedule configurable and change the default to RunFixedMainLoop

### DIFF
--- a/crates/bevy_landmass/src/lib.rs
+++ b/crates/bevy_landmass/src/lib.rs
@@ -94,6 +94,7 @@ impl<CS: CoordinateSystem> Default for LandmassPlugin<CS> {
 impl<CS: CoordinateSystem> LandmassPlugin<CS> {
   /// Sets the schedule for running the plugin. Defaults to
   /// [`RunFixedMainLoop`].
+  #[must_use]
   pub fn in_schedule(mut self, schedule: impl ScheduleLabel) -> Self {
     self.schedule = schedule.intern();
     self

--- a/crates/bevy_landmass/src/lib.rs
+++ b/crates/bevy_landmass/src/lib.rs
@@ -81,13 +81,13 @@ pub mod prelude {
 }
 
 pub struct LandmassPlugin<CS: CoordinateSystem> {
-  _pd: PhantomData<CS>,
   schedule: Interned<dyn ScheduleLabel>,
+  _marker: PhantomData<CS>,
 }
 
 impl<CS: CoordinateSystem> Default for LandmassPlugin<CS> {
   fn default() -> Self {
-    Self { _pd: Default::default(), schedule: RunFixedMainLoop.intern() }
+    Self { schedule: RunFixedMainLoop.intern(), _marker: Default::default() }
   }
 }
 

--- a/crates/landmass_oxidized_navigation/example/main.rs
+++ b/crates/landmass_oxidized_navigation/example/main.rs
@@ -30,7 +30,7 @@ fn main() {
     }))
     .add_plugins(Landmass3dPlugin::default())
     .add_plugins(Landmass3dDebugPlugin::default())
-    .add_plugins(LandmassOxidizedNavigationPlugin)
+    .add_plugins(LandmassOxidizedNavigationPlugin::default())
     .add_systems(Startup, setup)
     .add_systems(Update, handle_clicks)
     .add_systems(Update, toggle_debug.run_if(input_just_pressed(KeyCode::F12)))

--- a/crates/landmass_oxidized_navigation/src/lib.rs
+++ b/crates/landmass_oxidized_navigation/src/lib.rs
@@ -3,7 +3,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use bevy::{
-  app::{Plugin, Update},
+  app::{Plugin, RunFixedMainLoop},
   asset::Assets,
   log::warn,
   math::{UVec2, Vec3},
@@ -29,7 +29,7 @@ impl Plugin for LandmassOxidizedNavigationPlugin {
       .add_event::<UpdateTile>()
       .init_resource::<TileToIsland>()
       .add_systems(
-        Update,
+        RunFixedMainLoop,
         (LastTileGenerations::system, UpdateTile::system)
           .chain()
           .before(LandmassSystemSet::SyncExistence),

--- a/crates/landmass_oxidized_navigation/src/lib.rs
+++ b/crates/landmass_oxidized_navigation/src/lib.rs
@@ -28,6 +28,7 @@ pub struct LandmassOxidizedNavigationPlugin {
 impl LandmassOxidizedNavigationPlugin {
   /// Sets the schedule for running the plugin. Defaults to
   /// [`RunFixedMainLoop`].
+  #[must_use]
   pub fn in_schedule(mut self, schedule: impl ScheduleLabel) -> Self {
     self.schedule = schedule.intern();
     self

--- a/crates/landmass_oxidized_navigation/src/lib_test.rs
+++ b/crates/landmass_oxidized_navigation/src/lib_test.rs
@@ -37,7 +37,7 @@ fn generates_nav_mesh() {
     .add_plugins(OxidizedNavigationPlugin::<Collider>::new(
       NavMeshSettings::from_agent_and_bounds(0.5, 2.0, 100.0, -50.0),
     ))
-    .add_plugins(LandmassOxidizedNavigationPlugin);
+    .add_plugins(LandmassOxidizedNavigationPlugin::default());
 
   let archipelago_entity = app
     .world_mut()


### PR DESCRIPTION
Previously, we ran the navigation logic in `Update` - this occurs after `FixedUpdate` which is where physics movement (usually) occurs. Ideally we'd like to integrate as many changes and assign the most up-to-date desired movement *before* FixedUpdate. Putting it in `RunFixedMainLoop` allows us to do this.

In addition, this PR allows users to configure the scedule if that is not desirable. This does mean they will have an extraneous system set dependency in another schedule, but practically this won't matter.