### PR TITLE
Replace the `node_sample_distance` with a more expressive sampling options struct for 3D.

### DIFF
--- a/crates/bevy_landmass/README.md
+++ b/crates/bevy_landmass/README.md
@@ -46,7 +46,7 @@ fn set_up_scene(
   mut nav_meshes: ResMut<Assets<NavMesh2d>>,
 ) {
   let archipelago_id = commands
-    .spawn(Archipelago2d::new(AgentOptions::default_for_agent_radius(0.5)))
+    .spawn(Archipelago2d::new(AgentOptions::from_agent_radius(0.5)))
     .id();
 
   let nav_mesh_handle = nav_meshes.reserve_handle();

--- a/crates/bevy_landmass/example/main.rs
+++ b/crates/bevy_landmass/example/main.rs
@@ -8,7 +8,7 @@ use bevy_landmass::{
   debug::{EnableLandmassDebug, Landmass2dDebugPlugin},
   nav_mesh::bevy_mesh_to_landmass_nav_mesh,
   prelude::*,
-  AgentNodeTypeCostOverrides, NavMeshHandle,
+  AgentNodeTypeCostOverrides, FromAgentRadius, NavMeshHandle,
 };
 use landmass::NodeType;
 
@@ -121,7 +121,7 @@ fn setup(
   ));
 
   let mut archipelago =
-    Archipelago2d::new(AgentOptions::default_for_agent_radius(0.5));
+    Archipelago2d::new(AgentOptions::from_agent_radius(0.5));
   let slow_node_type = archipelago.add_node_type(1000.0).unwrap();
   let archipelago_entity = commands.spawn(archipelago).id();
 

--- a/crates/bevy_landmass/src/coords.rs
+++ b/crates/bevy_landmass/src/coords.rs
@@ -1,10 +1,13 @@
 use bevy::{math::Vec3Swizzles, reflect::TypePath};
 pub use landmass::CoordinateSystem as LandmassCoordinateSystem;
+use landmass::PointSampleDistance3d;
 
 /// A [`landmass::CoordinateSystem`] compatible with `bevy_landmass`.
 pub trait CoordinateSystem:
-  LandmassCoordinateSystem<Coordinate: Default + Send + Sync + PartialEq>
-  + TypePath
+  LandmassCoordinateSystem<
+    Coordinate: Default + Send + Sync + PartialEq,
+    SampleDistance: Send + Sync,
+  > + TypePath
   + Send
   + Sync
 {
@@ -28,6 +31,7 @@ pub struct ThreeD;
 
 impl LandmassCoordinateSystem for ThreeD {
   type Coordinate = bevy::math::Vec3;
+  type SampleDistance = PointSampleDistance3d;
 
   fn to_landmass(v: &Self::Coordinate) -> landmass::Vec3 {
     landmass::Vec3::new(v.x, -v.z, v.y)
@@ -62,6 +66,7 @@ pub struct TwoD;
 
 impl LandmassCoordinateSystem for TwoD {
   type Coordinate = bevy::math::Vec2;
+  type SampleDistance = f32;
 
   fn to_landmass(v: &Self::Coordinate) -> landmass::Vec3 {
     landmass::Vec3::new(v.x, v.y, 0.0)

--- a/crates/bevy_landmass/src/debug_test.rs
+++ b/crates/bevy_landmass/src/debug_test.rs
@@ -7,12 +7,11 @@ use bevy::{
   prelude::{Transform, TransformPlugin},
   MinimalPlugins,
 };
-use landmass::AgentOptions;
 
 use crate::{
-  coords::ThreeD, Agent, Agent3dBundle, AgentSettings, Archipelago3d,
-  ArchipelagoRef3d, Island, Island3dBundle, Landmass3dPlugin, NavMesh3d,
-  NavMeshHandle, NavigationMesh3d,
+  coords::ThreeD, Agent, Agent3dBundle, AgentOptions, AgentSettings,
+  Archipelago3d, ArchipelagoRef3d, FromAgentRadius, Island, Island3dBundle,
+  Landmass3dPlugin, NavMesh3d, NavMeshHandle, NavigationMesh3d,
 };
 
 use super::{
@@ -86,7 +85,7 @@ fn draws_archipelago_debug() {
 
   let archipelago_id = app
     .world_mut()
-    .spawn(Archipelago3d::new(AgentOptions::default_for_agent_radius(0.5)))
+    .spawn(Archipelago3d::new(AgentOptions::from_agent_radius(0.5)))
     .id();
 
   let nav_mesh = Arc::new(
@@ -244,7 +243,7 @@ fn draws_avoidance_data_when_requested() {
       neighbourhood: 100.0,
       avoidance_time_horizon: 100.0,
       obstacle_avoidance_time_horizon: 100.0,
-      ..AgentOptions::default_for_agent_radius(0.5)
+      ..AgentOptions::from_agent_radius(0.5)
     }))
     .id();
 

--- a/crates/bevy_landmass/src/lib.rs
+++ b/crates/bevy_landmass/src/lib.rs
@@ -21,15 +21,11 @@ mod character;
 mod island;
 mod landmass_structs;
 
-pub use landmass::AgentOptions;
-pub use landmass::FindPathError;
-pub use landmass::NavigationMesh;
-pub use landmass::NewNodeTypeError;
-pub use landmass::NodeType;
-pub use landmass::SamplePointError;
-pub use landmass::SetNodeTypeCostError;
-pub use landmass::ValidNavigationMesh;
-pub use landmass::ValidationError;
+pub use landmass::{
+  AgentOptions, FindPathError, FromAgentRadius, NavigationMesh,
+  NewNodeTypeError, NodeType, PointSampleDistance3d, SamplePointError,
+  SetNodeTypeCostError, ValidNavigationMesh, ValidationError,
+};
 
 pub use agent::*;
 pub use character::*;
@@ -62,6 +58,7 @@ pub mod prelude {
   pub use crate::Character2dBundle;
   pub use crate::Character3dBundle;
   pub use crate::CharacterSettings;
+  pub use crate::FromAgentRadius;
   pub use crate::Island;
   pub use crate::Island2dBundle;
   pub use crate::Island3dBundle;
@@ -190,7 +187,7 @@ pub type Archipelago3d = Archipelago<ThreeD>;
 
 impl<CS: CoordinateSystem> Archipelago<CS> {
   /// Creates an empty archipelago.
-  pub fn new(agent_options: AgentOptions) -> Self {
+  pub fn new(agent_options: AgentOptions<CS>) -> Self {
     Self {
       archipelago: landmass::Archipelago::new(agent_options),
       islands: HashMap::new(),
@@ -202,12 +199,12 @@ impl<CS: CoordinateSystem> Archipelago<CS> {
   }
 
   /// Gets the agent options.
-  pub fn get_agent_options(&self) -> &AgentOptions {
+  pub fn get_agent_options(&self) -> &AgentOptions<CS> {
     &self.archipelago.agent_options
   }
 
   /// Gets a mutable borrow to the agent options.
-  pub fn get_agent_options_mut(&mut self) -> &mut AgentOptions {
+  pub fn get_agent_options_mut(&mut self) -> &mut AgentOptions<CS> {
     &mut self.archipelago.agent_options
   }
 
@@ -251,10 +248,10 @@ impl<CS: CoordinateSystem> Archipelago<CS> {
   pub fn sample_point(
     &self,
     point: CS::Coordinate,
-    distance_to_node: f32,
+    point_sample_distance: &CS::SampleDistance,
   ) -> Result<SampledPoint<'_, CS>, SamplePointError> {
     let sampled_point =
-      self.archipelago.sample_point(point, distance_to_node)?;
+      self.archipelago.sample_point(point, point_sample_distance)?;
     Ok(SampledPoint {
       island: *self
         .reverse_islands

--- a/crates/bevy_landmass/src/lib_test.rs
+++ b/crates/bevy_landmass/src/lib_test.rs
@@ -1,15 +1,15 @@
 use std::{collections::HashMap, sync::Arc};
 
 use bevy::prelude::*;
-use landmass::{NavigationMesh, SamplePointError};
 
 use crate::{
   Agent2dBundle, Agent3dBundle, AgentDesiredVelocity2d, AgentDesiredVelocity3d,
   AgentNodeTypeCostOverrides, AgentOptions, AgentSettings, AgentState,
   AgentTarget2d, AgentTarget3d, Archipelago2d, Archipelago3d, ArchipelagoRef2d,
-  ArchipelagoRef3d, Character3dBundle, CharacterSettings, Island,
-  Island2dBundle, Island3dBundle, Landmass2dPlugin, Landmass3dPlugin,
-  NavMesh2d, NavMesh3d, NavMeshHandle, NavigationMesh3d, Velocity3d,
+  ArchipelagoRef3d, Character3dBundle, CharacterSettings, FromAgentRadius,
+  Island, Island2dBundle, Island3dBundle, Landmass2dPlugin, Landmass3dPlugin,
+  NavMesh2d, NavMesh3d, NavMeshHandle, NavigationMesh, NavigationMesh3d,
+  SamplePointError, Velocity3d,
 };
 
 #[test]
@@ -26,7 +26,7 @@ fn computes_path_for_agent_and_updates_desired_velocity() {
 
   let archipelago_id = app
     .world_mut()
-    .spawn(Archipelago3d::new(AgentOptions::default_for_agent_radius(0.5)))
+    .spawn(Archipelago3d::new(AgentOptions::from_agent_radius(0.5)))
     .id();
 
   let nav_mesh = Arc::new(
@@ -114,7 +114,7 @@ fn adds_and_removes_agents() {
 
   let archipelago_id = app
     .world_mut()
-    .spawn(Archipelago3d::new(AgentOptions::default_for_agent_radius(0.5)))
+    .spawn(Archipelago3d::new(AgentOptions::from_agent_radius(0.5)))
     .id();
 
   let agent_id_1 = app
@@ -246,7 +246,7 @@ fn adds_and_removes_characters() {
 
   let archipelago_id = app
     .world_mut()
-    .spawn(Archipelago3d::new(AgentOptions::default_for_agent_radius(0.5)))
+    .spawn(Archipelago3d::new(AgentOptions::from_agent_radius(0.5)))
     .id();
 
   let character_id_1 = app
@@ -350,7 +350,7 @@ fn adds_and_removes_islands() {
 
   let archipelago_id = app
     .world_mut()
-    .spawn(Archipelago3d::new(AgentOptions::default_for_agent_radius(0.5)))
+    .spawn(Archipelago3d::new(AgentOptions::from_agent_radius(0.5)))
     .id();
 
   let nav_mesh =
@@ -485,7 +485,7 @@ fn changing_agent_fields_changes_landmass_agent() {
 
   let archipelago = app
     .world_mut()
-    .spawn(Archipelago3d::new(AgentOptions::default_for_agent_radius(0.5)))
+    .spawn(Archipelago3d::new(AgentOptions::from_agent_radius(0.5)))
     .id();
 
   let agent = app
@@ -578,7 +578,7 @@ fn changing_character_fields_changes_landmass_character() {
 
   let archipelago = app
     .world_mut()
-    .spawn(Archipelago3d::new(AgentOptions::default_for_agent_radius(0.5)))
+    .spawn(Archipelago3d::new(AgentOptions::from_agent_radius(0.5)))
     .id();
 
   let character = app
@@ -639,7 +639,7 @@ fn node_type_costs_are_used() {
   app.update();
 
   let mut archipelago =
-    Archipelago2d::new(AgentOptions::default_for_agent_radius(0.5));
+    Archipelago2d::new(AgentOptions::from_agent_radius(0.5));
   let slow_node_type = archipelago.add_node_type(10.0).unwrap();
 
   let archipelago_id = app.world_mut().spawn(archipelago).id();
@@ -757,7 +757,7 @@ fn overridden_node_type_costs_are_used() {
   app.update();
 
   let mut archipelago =
-    Archipelago2d::new(AgentOptions::default_for_agent_radius(0.5));
+    Archipelago2d::new(AgentOptions::from_agent_radius(0.5));
   let slow_node_type = archipelago.add_node_type(1.0).unwrap();
 
   let archipelago_id = app.world_mut().spawn(archipelago).id();
@@ -881,7 +881,7 @@ fn sample_point_error_on_out_of_range() {
 
   let archipelago_entity = app
     .world_mut()
-    .spawn(Archipelago2d::new(AgentOptions::default_for_agent_radius(0.5)))
+    .spawn(Archipelago2d::new(AgentOptions::from_agent_radius(0.5)))
     .id();
 
   let nav_mesh = Arc::new(
@@ -915,7 +915,7 @@ fn sample_point_error_on_out_of_range() {
     app.world().get::<Archipelago2d>(archipelago_entity).unwrap();
 
   assert_eq!(
-    archipelago.sample_point(Vec2::new(-0.5, 0.5), 0.1).map(|p| p.point()),
+    archipelago.sample_point(Vec2::new(-0.5, 0.5), &0.1).map(|p| p.point()),
     Err(SamplePointError::OutOfRange)
   );
 }
@@ -935,7 +935,7 @@ fn samples_point_on_nav_mesh_or_near_nav_mesh() {
 
   let archipelago_entity = app
     .world_mut()
-    .spawn(Archipelago2d::new(AgentOptions::default_for_agent_radius(0.5)))
+    .spawn(Archipelago2d::new(AgentOptions::from_agent_radius(0.5)))
     .id();
 
   let nav_mesh = Arc::new(
@@ -979,7 +979,7 @@ fn samples_point_on_nav_mesh_or_near_nav_mesh() {
     archipelago
       .sample_point(
         /* point= */ offset + Vec2::new(-0.5, 0.5),
-        /* distance_to_node= */ 0.6
+        /* distance_to_node= */ &0.6
       )
       .map(|p| (p.island(), p.point())),
     Ok((island_id, offset + Vec2::new(0.0, 0.5)))
@@ -988,7 +988,7 @@ fn samples_point_on_nav_mesh_or_near_nav_mesh() {
     archipelago
       .sample_point(
         /* point= */ offset + Vec2::new(0.5, 0.5),
-        /* distance_to_node= */ 0.6
+        /* distance_to_node= */ &0.6
       )
       .map(|p| (p.island(), p.point())),
     Ok((island_id, offset + Vec2::new(0.5, 0.5)))
@@ -997,7 +997,7 @@ fn samples_point_on_nav_mesh_or_near_nav_mesh() {
     archipelago
       .sample_point(
         /* point= */ offset + Vec2::new(1.2, 1.2),
-        /* distance_to_node= */ 0.6
+        /* distance_to_node= */ &0.6
       )
       .map(|p| (p.island(), p.point())),
     Ok((island_id, offset + Vec2::new(1.0, 1.0)))
@@ -1018,7 +1018,7 @@ fn samples_node_types() {
   app.update();
 
   let mut archipelago =
-    Archipelago2d::new(AgentOptions::default_for_agent_radius(0.5));
+    Archipelago2d::new(AgentOptions::from_agent_radius(0.5));
   let node_type = archipelago.add_node_type(2.0).unwrap();
   let archipelago_entity = app.world_mut().spawn(archipelago).id();
 
@@ -1063,7 +1063,7 @@ fn samples_node_types() {
     archipelago
       .sample_point(
         /* point= */ offset + Vec2::new(0.5, 0.5),
-        /* distance_to_node= */ 0.1
+        /* distance_to_node= */ &0.1
       )
       .map(|p| p.node_type()),
     Ok(None)
@@ -1072,7 +1072,7 @@ fn samples_node_types() {
     archipelago
       .sample_point(
         /* point= */ offset + Vec2::new(1.5, 0.5),
-        /* distance_to_node= */ 0.1
+        /* distance_to_node= */ &0.1
       )
       .map(|p| p.node_type()),
     Ok(Some(node_type))
@@ -1094,7 +1094,7 @@ fn finds_path() {
 
   let archipelago_entity = app
     .world_mut()
-    .spawn(Archipelago2d::new(AgentOptions::default_for_agent_radius(0.5)))
+    .spawn(Archipelago2d::new(AgentOptions::from_agent_radius(0.5)))
     .id();
 
   let nav_mesh = Arc::new(
@@ -1146,10 +1146,10 @@ fn finds_path() {
   let archipelago =
     app.world().get::<Archipelago2d>(archipelago_entity).unwrap();
   let start_point = archipelago
-    .sample_point(Vec2::new(0.5, 0.5), 1e-5)
+    .sample_point(Vec2::new(0.5, 0.5), &1e-5)
     .expect("point is on nav mesh.");
   let end_point = archipelago
-    .sample_point(Vec2::new(2.5, 1.25), 1e-5)
+    .sample_point(Vec2::new(2.5, 1.25), &1e-5)
     .expect("point is on nav mesh.");
   assert_eq!(
     archipelago.find_path(&start_point, &end_point, &HashMap::new()),
@@ -1172,7 +1172,7 @@ fn island_matches_rotation_3d() {
 
   let archipelago_entity = app
     .world_mut()
-    .spawn(Archipelago3d::new(AgentOptions::default_for_agent_radius(0.5)))
+    .spawn(Archipelago3d::new(AgentOptions::from_agent_radius(0.5)))
     .id();
 
   let nav_mesh = Arc::new(
@@ -1235,7 +1235,7 @@ fn island_matches_rotation_2d() {
 
   let archipelago_entity = app
     .world_mut()
-    .spawn(Archipelago2d::new(AgentOptions::default_for_agent_radius(0.5)))
+    .spawn(Archipelago2d::new(AgentOptions::from_agent_radius(0.5)))
     .id();
 
   let nav_mesh = Arc::new(

--- a/crates/landmass/README.md
+++ b/crates/landmass/README.md
@@ -55,7 +55,7 @@ use landmass::*;
 use std::{sync::Arc, collections::HashMap};
 
 let mut archipelago =
-  Archipelago::<XYZ>::new(AgentOptions::default_for_agent_radius(0.5));
+  Archipelago::<XYZ>::new(AgentOptions::from_agent_radius(0.5));
 
 let nav_mesh = NavigationMesh {
   vertices: vec![

--- a/crates/landmass/src/agent_test.rs
+++ b/crates/landmass/src/agent_test.rs
@@ -12,8 +12,8 @@ use crate::{
   coords::{XY, XYZ},
   nav_data::NodeRef,
   path::{IslandSegment, Path, PathIndex},
-  Agent, AgentOptions, Archipelago, Island, IslandId, NavigationMesh, NodeType,
-  TargetReachedCondition, Transform,
+  Agent, AgentOptions, Archipelago, FromAgentRadius, Island, IslandId,
+  NavigationMesh, NodeType, TargetReachedCondition, Transform,
 };
 
 #[test]
@@ -94,7 +94,7 @@ fn has_reached_target_at_end_node() {
   let transform =
     Transform { translation: Vec3::new(2.0, 3.0, 4.0), rotation: PI * 0.85 };
   let mut archipelago =
-    Archipelago::<XYZ>::new(AgentOptions::default_for_agent_radius(0.5));
+    Archipelago::<XYZ>::new(AgentOptions::from_agent_radius(0.5));
   let island_id = archipelago.add_island(Island::new(
     transform.clone(),
     Arc::new(nav_mesh),
@@ -172,7 +172,7 @@ fn long_detour_reaches_target_in_different_ways() {
   let transform =
     Transform { translation: Vec3::new(2.0, 4.0, 3.0), rotation: PI * -0.85 };
   let mut archipelago =
-    Archipelago::<XYZ>::new(AgentOptions::default_for_agent_radius(0.5));
+    Archipelago::<XYZ>::new(AgentOptions::from_agent_radius(0.5));
   let island_id = archipelago.add_island(Island::new(
     transform.clone(),
     Arc::new(nav_mesh),

--- a/crates/landmass/src/avoidance.rs
+++ b/crates/landmass/src/avoidance.rs
@@ -19,7 +19,7 @@ pub(crate) fn apply_avoidance_to_agents<CS: CoordinateSystem>(
   characters: &HopSlotMap<CharacterId, Character<CS>>,
   character_id_to_nav_mesh_point: &HashMap<CharacterId, Vec3>,
   nav_data: &NavigationData<CS>,
-  agent_options: &AgentOptions,
+  agent_options: &AgentOptions<CS>,
   mut delta_time: f32,
 ) {
   if delta_time == 0.0 {

--- a/crates/landmass/src/avoidance_test.rs
+++ b/crates/landmass/src/avoidance_test.rs
@@ -7,8 +7,8 @@ use crate::{
   avoidance::apply_avoidance_to_agents,
   coords::{XY, XYZ},
   nav_data::NodeRef,
-  Agent, AgentId, AgentOptions, Archipelago, Character, CharacterId, Island,
-  NavigationData, NavigationMesh, Transform,
+  Agent, AgentId, AgentOptions, Archipelago, Character, CharacterId,
+  FromAgentRadius, Island, NavigationData, NavigationMesh, Transform,
 };
 
 use super::nav_mesh_borders_to_dodgy_obstacles;
@@ -469,7 +469,7 @@ fn applies_no_avoidance_for_far_agents() {
     &nav_data,
     &AgentOptions {
       neighbourhood: 5.0,
-      ..AgentOptions::default_for_agent_radius(0.5)
+      ..AgentOptions::from_agent_radius(0.5)
     },
     /* delta_time= */ 0.01,
   );
@@ -559,7 +559,7 @@ fn applies_avoidance_for_two_agents() {
     &AgentOptions {
       neighbourhood: 15.0,
       avoidance_time_horizon: 15.0,
-      ..AgentOptions::default_for_agent_radius(0.5)
+      ..AgentOptions::from_agent_radius(0.5)
     },
     /* delta_time= */ 0.0,
   );
@@ -645,7 +645,7 @@ fn agent_avoids_character() {
     &AgentOptions {
       neighbourhood: 15.0,
       avoidance_time_horizon: 15.0,
-      ..AgentOptions::default_for_agent_radius(0.5)
+      ..AgentOptions::from_agent_radius(0.5)
     },
     /* delta_time= */ 0.01,
   );
@@ -718,7 +718,7 @@ fn agent_speeds_up_to_avoid_character() {
     &AgentOptions {
       neighbourhood: 15.0,
       avoidance_time_horizon: 15.0,
-      ..AgentOptions::default_for_agent_radius(0.5)
+      ..AgentOptions::from_agent_radius(0.5)
     },
     /* delta_time= */ 0.01,
   );
@@ -748,7 +748,7 @@ fn agent_speeds_up_to_avoid_character() {
     &AgentOptions {
       neighbourhood: 15.0,
       avoidance_time_horizon: 15.0,
-      ..AgentOptions::default_for_agent_radius(0.5)
+      ..AgentOptions::from_agent_radius(0.5)
     },
     /* delta_time= */ 0.01,
   );
@@ -766,7 +766,7 @@ fn agent_speeds_up_to_avoid_character() {
 #[test]
 fn reached_target_agent_has_different_avoidance() {
   let mut archipelago =
-    Archipelago::<XY>::new(AgentOptions::default_for_agent_radius(0.5));
+    Archipelago::<XY>::new(AgentOptions::from_agent_radius(0.5));
 
   let nav_mesh = Arc::new(
     NavigationMesh {

--- a/crates/landmass/src/coords.rs
+++ b/crates/landmass/src/coords.rs
@@ -6,6 +6,8 @@ use glam::{Vec2, Vec3};
 pub trait CoordinateSystem {
   /// The user-facing coordinate type.
   type Coordinate: Clone;
+  /// The type to use for point sampling options.
+  type SampleDistance: PointSampleDistance;
 
   /// Converts a coordinate in this system to the standard coordinate system.
   fn to_landmass(v: &Self::Coordinate) -> Vec3;
@@ -14,12 +16,46 @@ pub trait CoordinateSystem {
   fn from_landmass(v: &Vec3) -> Self::Coordinate;
 }
 
+/// A configuration of how a type relates to distances when sampling points. See
+/// [`crate::Archipelago::sample_point`] for more.
+pub trait PointSampleDistance {
+  /// The horizontal distance that a node may be sampled. If a sample point is
+  /// further than this distance away horizontally, it will be ignored.
+  fn horizontal_distance(&self) -> f32;
+
+  /// The vertical distance above the query point that a node may be sampled.
+  ///
+  /// If a sample point is further above than this distance, it will be ignored.
+  /// For 2D coordinate systems, this value is not really used, but a value of
+  /// 1.0 is good to avoid floating point errors. This value must be greater
+  /// than negative [`PointSampleDistance::distance_below`] (and preferably
+  /// positive).
+  fn distance_above(&self) -> f32;
+
+  /// The vertical distance below the query point that a node may be sampled.
+  ///
+  /// If a sample point is further below than this distance, it will be ignored.
+  /// For 2D coordinate systems, this value is not really used, but a value of
+  /// 1.0 is good to avoid floating point errors. This value must be less than
+  /// than negative [`PointSampleDistance::distance_above`] (and preferably
+  /// positive).
+  fn distance_below(&self) -> f32;
+
+  /// The ratio between the vertical and the horizontal distances to prefer. For
+  /// example, if this value is 2.0, then a sample point directly below the
+  /// query point 1.9 units away will be selected over a sample point 1.0 unit
+  /// away horizontally. This value must be positive. For 2D coordinate systems,
+  /// the value is irrelevant (so 1.0 is preferred).
+  fn vertical_preference_ratio(&self) -> f32;
+}
+
 /// The standard coordinate system, where X points right, Y points forward, and
 /// Z points up.
 pub struct XYZ;
 
 impl CoordinateSystem for XYZ {
   type Coordinate = Vec3;
+  type SampleDistance = PointSampleDistance3d;
 
   fn to_landmass(v: &Self::Coordinate) -> Vec3 {
     *v
@@ -30,11 +66,53 @@ impl CoordinateSystem for XYZ {
   }
 }
 
+/// A [`PointSampleDistance`] type for 3D coordinate systems.
+#[derive(Debug, PartialEq, Clone)]
+pub struct PointSampleDistance3d {
+  /// The horizontal distance that a node may be sampled. If a sample point is
+  /// further than this distance away horizontally, it will be ignored.
+  pub horizontal_distance: f32,
+
+  /// The vertical distance above the query point that a node may be sampled.
+  ///
+  /// If a sample point is further above than this distance, it will be
+  /// ignored. This value must be greater than [`Self::distance_below`].
+  pub distance_above: f32,
+
+  /// The vertical distance below the query point that a node may be sampled.
+  ///
+  /// If a sample point is further below than this distance, it will be
+  /// ignored. This value must be greater than [`Self::distance_above`].
+  pub distance_below: f32,
+
+  /// The ratio between the vertical and the horizontal distances to prefer.
+  /// For example, if this value is 2.0, then a sample point directly below
+  /// the query point 1.9 units away will be selected over a sample point 1.0
+  /// unit away horizontally. This value must be positive.
+  pub vertical_preference_ratio: f32,
+}
+
+impl PointSampleDistance for PointSampleDistance3d {
+  fn horizontal_distance(&self) -> f32 {
+    self.horizontal_distance
+  }
+  fn distance_above(&self) -> f32 {
+    self.distance_above
+  }
+  fn distance_below(&self) -> f32 {
+    self.distance_below
+  }
+  fn vertical_preference_ratio(&self) -> f32 {
+    self.vertical_preference_ratio
+  }
+}
+
 /// A 2D coordinate system, where X points right, and Y points forward.
 pub struct XY;
 
 impl CoordinateSystem for XY {
   type Coordinate = Vec2;
+  type SampleDistance = f32;
 
   fn to_landmass(v: &Self::Coordinate) -> Vec3 {
     Vec3::new(v.x, v.y, 0.0)
@@ -42,5 +120,23 @@ impl CoordinateSystem for XY {
 
   fn from_landmass(v: &Vec3) -> Self::Coordinate {
     Vec2::new(v.x, v.y)
+  }
+}
+
+impl PointSampleDistance for f32 {
+  fn horizontal_distance(&self) -> f32 {
+    *self
+  }
+
+  fn distance_above(&self) -> f32 {
+    1.0
+  }
+
+  fn distance_below(&self) -> f32 {
+    1.0
+  }
+
+  fn vertical_preference_ratio(&self) -> f32 {
+    1.0
   }
 }

--- a/crates/landmass/src/coords.rs
+++ b/crates/landmass/src/coords.rs
@@ -16,6 +16,14 @@ pub trait CoordinateSystem {
   fn from_landmass(v: &Vec3) -> Self::Coordinate;
 }
 
+/// A trait to create a default instance based on an agent's radius.
+///
+/// This is an easy starting point when using struct-update-syntax.
+pub trait FromAgentRadius {
+  /// Creates an instance given the agent's radius.
+  fn from_agent_radius(radius: f32) -> Self;
+}
+
 /// A configuration of how a type relates to distances when sampling points. See
 /// [`crate::Archipelago::sample_point`] for more.
 pub trait PointSampleDistance {
@@ -107,6 +115,17 @@ impl PointSampleDistance for PointSampleDistance3d {
   }
 }
 
+impl FromAgentRadius for PointSampleDistance3d {
+  fn from_agent_radius(radius: f32) -> Self {
+    Self {
+      horizontal_distance: 0.2 * radius,
+      distance_above: 0.5 * radius,
+      distance_below: radius,
+      vertical_preference_ratio: 2.0,
+    }
+  }
+}
+
 /// A 2D coordinate system, where X points right, and Y points forward.
 pub struct XY;
 
@@ -138,5 +157,11 @@ impl PointSampleDistance for f32 {
 
   fn vertical_preference_ratio(&self) -> f32 {
     1.0
+  }
+}
+
+impl FromAgentRadius for f32 {
+  fn from_agent_radius(radius: f32) -> Self {
+    0.2 * radius
   }
 }

--- a/crates/landmass/src/debug.rs
+++ b/crates/landmass/src/debug.rs
@@ -213,14 +213,14 @@ fn draw_path<CS: CoordinateSystem>(
     .nav_data
     .sample_point(
       CS::to_landmass(&agent.position),
-      archipelago.agent_options.node_sample_distance,
+      &archipelago.agent_options.point_sample_distance,
     )
     .expect("Path exists, so sampling the agent should be fine.");
   let (target_sample_point, target_node_ref) = archipelago
     .nav_data
     .sample_point(
       CS::to_landmass(&target),
-      archipelago.agent_options.node_sample_distance,
+      &archipelago.agent_options.point_sample_distance,
     )
     .expect("Path exists, so sampling the agent should be fine.");
 

--- a/crates/landmass/src/debug_test.rs
+++ b/crates/landmass/src/debug_test.rs
@@ -5,7 +5,8 @@ use glam::Vec3;
 use crate::{
   coords::XYZ,
   debug::{DebugDrawError, DebugDrawer, LineType, PointType, TriangleType},
-  Agent, AgentOptions, Archipelago, Island, NavigationMesh, Transform,
+  Agent, AgentOptions, Archipelago, FromAgentRadius, Island, NavigationMesh,
+  Transform,
 };
 
 use super::draw_archipelago_debug;
@@ -95,7 +96,7 @@ fn draws_island_meshes_and_agents() {
   .expect("Mesh is valid.");
 
   let mut archipelago =
-    Archipelago::<XYZ>::new(AgentOptions::default_for_agent_radius(0.5));
+    Archipelago::<XYZ>::new(AgentOptions::from_agent_radius(0.5));
   const TRANSLATION: Vec3 = Vec3::ONE;
   archipelago.add_island(Island::new(
     Transform { translation: TRANSLATION, rotation: 0.0 },
@@ -431,7 +432,7 @@ fn draws_boundary_links() {
   );
 
   let mut archipelago =
-    Archipelago::<XYZ>::new(AgentOptions::default_for_agent_radius(0.5));
+    Archipelago::<XYZ>::new(AgentOptions::from_agent_radius(0.5));
   archipelago.add_island(Island::new(
     Transform::default(),
     nav_mesh.clone(),
@@ -482,7 +483,7 @@ fn fails_to_draw_dirty_archipelago() {
 
   // A brand new archipelago is considered clean.
   let mut archipelago =
-    Archipelago::<XYZ>::new(AgentOptions::default_for_agent_radius(0.5));
+    Archipelago::<XYZ>::new(AgentOptions::from_agent_radius(0.5));
   assert_eq!(draw_archipelago_debug(&archipelago, &mut fake_drawer), Ok(()));
 
   // Creating an island marks the nav data as dirty.
@@ -540,7 +541,7 @@ fn draws_avoidance_data_when_requested() {
     neighbourhood: 100.0,
     avoidance_time_horizon: 100.0,
     obstacle_avoidance_time_horizon: 100.0,
-    ..AgentOptions::default_for_agent_radius(0.5)
+    ..AgentOptions::from_agent_radius(0.5)
   });
   archipelago.add_island(Island::new(
     Transform::default(),

--- a/crates/landmass/src/lib.rs
+++ b/crates/landmass/src/lib.rs
@@ -15,7 +15,6 @@ mod query;
 mod util;
 
 use agent::{does_agent_need_repath, RepathResult};
-use coords::FromAgentRadius;
 use path::PathIndex;
 use slotmap::HopSlotMap;
 use std::collections::HashMap;
@@ -28,7 +27,10 @@ pub mod debug;
 
 pub use agent::{Agent, AgentId, AgentState, TargetReachedCondition};
 pub use character::{Character, CharacterId};
-pub use coords::{CoordinateSystem, XYZ};
+pub use coords::{
+  CoordinateSystem, FromAgentRadius, PointSampleDistance,
+  PointSampleDistance3d, XY, XYZ,
+};
 pub use island::{Island, IslandId};
 pub use nav_data::{
   IslandMut, NewNodeTypeError, NodeType, SetNodeTypeCostError,

--- a/crates/landmass/src/nav_mesh_test.rs
+++ b/crates/landmass/src/nav_mesh_test.rs
@@ -6,6 +6,7 @@ use crate::{
   coords::XYZ,
   nav_mesh::{Connectivity, MeshEdgeRef, ValidPolygon},
   util::BoundingBox,
+  PointSampleDistance3d,
 };
 
 use super::{NavigationMesh, ValidationError};
@@ -442,7 +443,12 @@ fn sample_point_returns_none_for_far_point() {
   assert_eq!(
     mesh.sample_point(
       /* point= */ Vec3::new(-3.0, 0.0, 0.0),
-      /* distance_to_node= */ 0.1
+      &PointSampleDistance3d {
+        horizontal_distance: 0.1,
+        distance_below: 0.1,
+        distance_above: 0.1,
+        vertical_preference_ratio: 1.0,
+      },
     ),
     None
   );
@@ -450,7 +456,12 @@ fn sample_point_returns_none_for_far_point() {
   assert_eq!(
     mesh.sample_point(
       /* point= */ Vec3::new(6.0, 0.0, 0.0),
-      /* distance_to_node= */ 0.1
+      &PointSampleDistance3d {
+        horizontal_distance: 0.1,
+        distance_below: 0.1,
+        distance_above: 0.1,
+        vertical_preference_ratio: 1.0,
+      },
     ),
     None
   );
@@ -458,7 +469,12 @@ fn sample_point_returns_none_for_far_point() {
   assert_eq!(
     mesh.sample_point(
       /* point= */ Vec3::new(0.0, 0.0, -3.0),
-      /* distance_to_node= */ 0.1
+      &PointSampleDistance3d {
+        horizontal_distance: 0.1,
+        distance_below: 0.1,
+        distance_above: 0.1,
+        vertical_preference_ratio: 1.0,
+      },
     ),
     None
   );
@@ -466,7 +482,12 @@ fn sample_point_returns_none_for_far_point() {
   assert_eq!(
     mesh.sample_point(
       /* point= */ Vec3::new(0.0, 0.0, 2.0),
-      /* distance_to_node= */ 0.1
+      &PointSampleDistance3d {
+        horizontal_distance: 0.1,
+        distance_below: 0.1,
+        distance_above: 0.1,
+        vertical_preference_ratio: 1.0,
+      },
     ),
     None
   );
@@ -508,7 +529,12 @@ fn sample_point_in_nodes() {
   assert_eq!(
     mesh.sample_point(
       /* point= */ Vec3::new(1.5, 1.5, 0.95),
-      /* distance_to_node= */ 1.0,
+      &PointSampleDistance3d {
+        horizontal_distance: 1.0,
+        distance_below: 1.0,
+        distance_above: 1.0,
+        vertical_preference_ratio: 1.0,
+      },
     ),
     Some((Vec3::new(1.5, 1.5, 0.0), 0))
   );
@@ -516,7 +542,12 @@ fn sample_point_in_nodes() {
   assert_eq!(
     mesh.sample_point(
       /* point= */ Vec3::new(1.5, 4.0, -0.95),
-      /* distance_to_node= */ 1.0,
+      &PointSampleDistance3d {
+        horizontal_distance: 1.0,
+        distance_below: 1.0,
+        distance_above: 1.0,
+        vertical_preference_ratio: 1.0,
+      },
     ),
     Some((Vec3::new(1.5, 4.0, 0.0), 1))
   );
@@ -524,7 +555,12 @@ fn sample_point_in_nodes() {
   assert_eq!(
     mesh.sample_point(
       /* point= */ Vec3::new(1.5, 4.0, -0.95),
-      /* distance_to_node= */ 1.0,
+      &PointSampleDistance3d {
+        horizontal_distance: 1.0,
+        distance_below: 1.0,
+        distance_above: 1.0,
+        vertical_preference_ratio: 1.0,
+      },
     ),
     Some((Vec3::new(1.5, 4.0, 0.0), 1))
   );
@@ -534,7 +570,12 @@ fn sample_point_in_nodes() {
   assert_eq!(
     mesh.sample_point(
       /* point= */ Vec3::new(2.5, 3.5, -0.55),
-      /* distance_to_node = */ 5.0
+      &PointSampleDistance3d {
+        horizontal_distance: 5.0,
+        distance_below: 5.0,
+        distance_above: 5.0,
+        vertical_preference_ratio: 1.0,
+      },
     ),
     Some((Vec3::new(2.5, 3.5, -1.0), 3))
   );
@@ -542,7 +583,12 @@ fn sample_point_in_nodes() {
     mesh
       .sample_point(
         /* point= */ Vec3::new(2.5, 4.5, 0.1),
-        /* distance_to_node = */ 5.0
+        &PointSampleDistance3d {
+          horizontal_distance: 5.0,
+          distance_below: 5.0,
+          distance_above: 5.0,
+          vertical_preference_ratio: 1.0,
+        },
       )
       .map(|(point, node)| ((point * 1000.0).round() / 1000.0, node)),
     Some((Vec3::new(2.5, 4.5, 0.5), 2))
@@ -585,7 +631,12 @@ fn sample_point_near_node() {
   assert_eq!(
     mesh.sample_point(
       /* point= */ Vec3::new(-0.5, 1.5, 0.25),
-      /* distance_to_node= */ 1.0,
+      &PointSampleDistance3d {
+        horizontal_distance: 1.0,
+        distance_below: 1.0,
+        distance_above: 1.0,
+        vertical_preference_ratio: 1.0,
+      },
     ),
     Some((Vec3::new(0.0, 1.5, 0.0), 0))
   );
@@ -593,7 +644,12 @@ fn sample_point_near_node() {
   assert_eq!(
     mesh.sample_point(
       /* point= */ Vec3::new(0.5, 5.5, -0.25),
-      /* distance_to_node= */ 1.0,
+      &PointSampleDistance3d {
+        horizontal_distance: 1.0,
+        distance_below: 1.0,
+        distance_above: 1.0,
+        vertical_preference_ratio: 1.0,
+      },
     ),
     Some((Vec3::new(1.0, 5.0, 0.0), 1))
   );
@@ -601,7 +657,12 @@ fn sample_point_near_node() {
   assert_eq!(
     mesh.sample_point(
       /* point= */ Vec3::new(4.5, 1.5, -0.25),
-      /* distance_to_node= */ 1.0,
+      &PointSampleDistance3d {
+        horizontal_distance: 1.0,
+        distance_below: 1.0,
+        distance_above: 1.0,
+        vertical_preference_ratio: 1.0,
+      },
     ),
     Some((Vec3::new(4.0, 1.5, 0.0), 0))
   );
@@ -611,7 +672,12 @@ fn sample_point_near_node() {
   assert_eq!(
     mesh.sample_point(
       /* point= */ Vec3::new(2.5, 5.5, 0.5),
-      /* distance_to_node = */ 5.0
+      &PointSampleDistance3d {
+        horizontal_distance: 5.0,
+        distance_below: 5.0,
+        distance_above: 5.0,
+        vertical_preference_ratio: 1.0,
+      },
     ),
     Some((Vec3::new(2.5, 5.0, 0.5), 2))
   );

--- a/crates/landmass/src/path_test.rs
+++ b/crates/landmass/src/path_test.rs
@@ -12,7 +12,8 @@ use crate::{
   nav_data::{BoundaryLinkId, NavigationData, NodeRef},
   nav_mesh::NavigationMesh,
   path::{BoundaryLinkSegment, IslandSegment},
-  AgentOptions, Archipelago, CoordinateSystem, Island, IslandId, Transform,
+  AgentOptions, Archipelago, CoordinateSystem, FromAgentRadius, Island,
+  IslandId, Transform,
 };
 
 use super::{Path, PathIndex};
@@ -73,7 +74,7 @@ fn finds_next_point_for_organic_map() {
   let transform =
     Transform { translation: Vec3::new(5.0, 9.0, 7.0), rotation: PI * -0.35 };
   let mut archipelago =
-    Archipelago::<XYZ>::new(AgentOptions::default_for_agent_radius(0.5));
+    Archipelago::<XYZ>::new(AgentOptions::from_agent_radius(0.5));
   let island_id = archipelago.add_island(Island::new(
     transform.clone(),
     Arc::new(nav_mesh),
@@ -180,7 +181,7 @@ fn finds_next_point_in_zig_zag() {
   let transform =
     Transform { translation: Vec2::new(-1.0, -3.0), rotation: PI * -1.8 };
   let mut archipelago =
-    Archipelago::<XY>::new(AgentOptions::default_for_agent_radius(0.5));
+    Archipelago::<XY>::new(AgentOptions::from_agent_radius(0.5));
   let island_id = archipelago.add_island(Island::new(
     transform.clone(),
     Arc::new(nav_mesh),
@@ -255,7 +256,7 @@ fn starts_at_end_index_goes_to_end_point() {
   .expect("Mesh is valid.");
 
   let mut archipelago =
-    Archipelago::<XYZ>::new(AgentOptions::default_for_agent_radius(0.5));
+    Archipelago::<XYZ>::new(AgentOptions::from_agent_radius(0.5));
   let island_id = archipelago.add_island(Island::new(
     Transform { translation: Vec3::ZERO, rotation: 0.0 },
     Arc::new(nav_mesh),

--- a/crates/landmass/src/pathfinding_test.rs
+++ b/crates/landmass/src/pathfinding_test.rs
@@ -7,7 +7,7 @@ use crate::{
   nav_data::NodeRef,
   nav_mesh::NavigationMesh,
   path::{BoundaryLinkSegment, IslandSegment, Path},
-  AgentOptions, Archipelago, Island, Transform,
+  AgentOptions, Archipelago, FromAgentRadius, Island, Transform,
 };
 
 use super::find_path;
@@ -44,7 +44,7 @@ fn finds_path_in_archipelago() {
   .expect("Mesh is valid.");
 
   let mut archipelago =
-    Archipelago::<XYZ>::new(AgentOptions::default_for_agent_radius(0.5));
+    Archipelago::<XYZ>::new(AgentOptions::from_agent_radius(0.5));
   let island_id = archipelago.add_island(Island::new(
     Transform { translation: Vec3::ZERO, rotation: 0.0 },
     Arc::new(nav_mesh),
@@ -144,7 +144,7 @@ fn finds_paths_on_two_islands() {
   let nav_mesh = Arc::new(nav_mesh);
 
   let mut archipelago =
-    Archipelago::<XYZ>::new(AgentOptions::default_for_agent_radius(0.5));
+    Archipelago::<XYZ>::new(AgentOptions::from_agent_radius(0.5));
   let island_id_1 = archipelago.add_island(Island::new(
     Transform { translation: Vec3::ZERO, rotation: 0.0 },
     Arc::clone(&nav_mesh),
@@ -231,7 +231,7 @@ fn no_path_between_disconnected_islands() {
   let nav_mesh = Arc::new(nav_mesh);
 
   let mut archipelago =
-    Archipelago::<XYZ>::new(AgentOptions::default_for_agent_radius(0.5));
+    Archipelago::<XYZ>::new(AgentOptions::from_agent_radius(0.5));
   let island_id_1 = archipelago.add_island(Island::new(
     Transform { translation: Vec3::ZERO, rotation: 0.0 },
     Arc::clone(&nav_mesh),
@@ -283,7 +283,7 @@ fn find_path_across_connected_islands() {
   );
 
   let mut archipelago =
-    Archipelago::<XYZ>::new(AgentOptions::default_for_agent_radius(0.5));
+    Archipelago::<XYZ>::new(AgentOptions::from_agent_radius(0.5));
 
   let island_id_1 = archipelago.add_island(Island::new(
     Transform { rotation: 0.0, translation: Vec3::ZERO },
@@ -410,7 +410,7 @@ fn finds_path_across_different_islands() {
   );
 
   let mut archipelago =
-    Archipelago::<XYZ>::new(AgentOptions::default_for_agent_radius(0.5));
+    Archipelago::<XYZ>::new(AgentOptions::from_agent_radius(0.5));
 
   let island_id_1 = archipelago.add_island(Island::new(
     Transform { rotation: 0.0, translation: Vec3::ZERO },
@@ -485,7 +485,7 @@ fn aborts_early_for_unconnected_regions() {
   );
 
   let mut archipelago =
-    Archipelago::<XYZ>::new(AgentOptions::default_for_agent_radius(0.5));
+    Archipelago::<XYZ>::new(AgentOptions::from_agent_radius(0.5));
 
   let island_id_1 = archipelago.add_island(Island::new(
     Transform { translation: Vec3::ZERO, rotation: 0.0 },
@@ -534,7 +534,7 @@ fn aborts_early_for_unconnected_regions() {
 #[test]
 fn detour_for_high_cost_path() {
   let mut archipelago =
-    Archipelago::<XY>::new(AgentOptions::default_for_agent_radius(0.5));
+    Archipelago::<XY>::new(AgentOptions::from_agent_radius(0.5));
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -613,7 +613,7 @@ fn detour_for_high_cost_path() {
 #[test]
 fn detour_for_high_cost_path_across_boundary_links() {
   let mut archipelago =
-    Archipelago::<XY>::new(AgentOptions::default_for_agent_radius(0.5));
+    Archipelago::<XY>::new(AgentOptions::from_agent_radius(0.5));
 
   let nav_mesh_1 = Arc::new(
     NavigationMesh {
@@ -722,7 +722,7 @@ fn detour_for_high_cost_path_across_boundary_links() {
 #[test]
 fn fast_path_not_ignored_by_heuristic() {
   let mut archipelago =
-    Archipelago::<XY>::new(AgentOptions::default_for_agent_radius(0.5));
+    Archipelago::<XY>::new(AgentOptions::from_agent_radius(0.5));
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -803,7 +803,7 @@ fn fast_path_not_ignored_by_heuristic() {
 #[test]
 fn infinite_or_nan_cost_cannot_find_path() {
   let mut archipelago =
-    Archipelago::<XY>::new(AgentOptions::default_for_agent_radius(0.5));
+    Archipelago::<XY>::new(AgentOptions::from_agent_radius(0.5));
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -858,7 +858,7 @@ fn infinite_or_nan_cost_cannot_find_path() {
 #[test]
 fn detour_for_overridden_high_cost_path() {
   let mut archipelago =
-    Archipelago::<XY>::new(AgentOptions::default_for_agent_radius(0.5));
+    Archipelago::<XY>::new(AgentOptions::from_agent_radius(0.5));
 
   let nav_mesh = Arc::new(
     NavigationMesh {

--- a/crates/landmass/src/query.rs
+++ b/crates/landmass/src/query.rs
@@ -61,17 +61,17 @@ pub enum SamplePointError {
 
 /// Finds the nearest point on the navigation meshes to (and within
 /// `distance_to_node` of) `point`.
-pub(crate) fn sample_point<CS: CoordinateSystem>(
-  archipelago: &Archipelago<CS>,
+pub(crate) fn sample_point<'archipelago, CS: CoordinateSystem>(
+  archipelago: &'archipelago Archipelago<CS>,
   point: CS::Coordinate,
-  distance_to_node: f32,
-) -> Result<SampledPoint<'_, CS>, SamplePointError> {
+  point_sample_distance: &'_ CS::SampleDistance,
+) -> Result<SampledPoint<'archipelago, CS>, SamplePointError> {
   if archipelago.nav_data.dirty {
     return Err(SamplePointError::NavDataDirty);
   }
   let Some((point, node_ref)) = archipelago
     .nav_data
-    .sample_point(CS::to_landmass(&point), distance_to_node)
+    .sample_point(CS::to_landmass(&point), point_sample_distance)
   else {
     return Err(SamplePointError::OutOfRange);
   };

--- a/crates/landmass/src/query_test.rs
+++ b/crates/landmass/src/query_test.rs
@@ -3,8 +3,8 @@ use std::{collections::HashMap, sync::Arc};
 use glam::Vec2;
 
 use crate::{
-  coords::XY, AgentOptions, Archipelago, FindPathError, Island, NavigationMesh,
-  SamplePointError, Transform,
+  coords::XY, AgentOptions, Archipelago, FindPathError, FromAgentRadius,
+  Island, NavigationMesh, SamplePointError, Transform,
 };
 
 use super::{find_path, sample_point};
@@ -12,7 +12,7 @@ use super::{find_path, sample_point};
 #[test]
 fn error_on_dirty_nav_mesh() {
   let mut archipelago =
-    Archipelago::<XY>::new(AgentOptions::default_for_agent_radius(0.5));
+    Archipelago::<XY>::new(AgentOptions::from_agent_radius(0.5));
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -38,7 +38,7 @@ fn error_on_dirty_nav_mesh() {
     sample_point(
       &archipelago,
       /* point= */ Vec2::new(0.5, 0.5),
-      /* distance_to_node= */ 1.0
+      /* distance_to_node= */ &1.0
     )
     .map(|p| p.point()),
     Err(SamplePointError::NavDataDirty)
@@ -48,7 +48,7 @@ fn error_on_dirty_nav_mesh() {
 #[test]
 fn error_on_out_of_range() {
   let mut archipelago =
-    Archipelago::<XY>::new(AgentOptions::default_for_agent_radius(0.5));
+    Archipelago::<XY>::new(AgentOptions::from_agent_radius(0.5));
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -76,7 +76,7 @@ fn error_on_out_of_range() {
     sample_point(
       &archipelago,
       /* point= */ Vec2::new(-0.5, 0.5),
-      /* distance_to_node= */ 0.1
+      /* distance_to_node= */ &0.1
     )
     .map(|p| p.point()),
     Err(SamplePointError::OutOfRange)
@@ -86,7 +86,7 @@ fn error_on_out_of_range() {
 #[test]
 fn samples_point_on_nav_mesh_or_near_nav_mesh() {
   let mut archipelago =
-    Archipelago::<XY>::new(AgentOptions::default_for_agent_radius(0.5));
+    Archipelago::<XY>::new(AgentOptions::from_agent_radius(0.5));
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -115,7 +115,7 @@ fn samples_point_on_nav_mesh_or_near_nav_mesh() {
     sample_point(
       &archipelago,
       /* point= */ offset + Vec2::new(-0.5, 0.5),
-      /* distance_to_node= */ 0.6
+      /* distance_to_node= */ &0.6
     )
     .map(|p| (p.island(), p.point())),
     Ok((island_id, offset + Vec2::new(0.0, 0.5)))
@@ -124,7 +124,7 @@ fn samples_point_on_nav_mesh_or_near_nav_mesh() {
     sample_point(
       &archipelago,
       /* point= */ offset + Vec2::new(0.5, 0.5),
-      /* distance_to_node= */ 0.6
+      /* distance_to_node= */ &0.6
     )
     .map(|p| (p.island(), p.point())),
     Ok((island_id, offset + Vec2::new(0.5, 0.5)))
@@ -133,7 +133,7 @@ fn samples_point_on_nav_mesh_or_near_nav_mesh() {
     sample_point(
       &archipelago,
       /* point= */ offset + Vec2::new(1.2, 1.2),
-      /* distance_to_node= */ 0.6
+      /* distance_to_node= */ &0.6
     )
     .map(|p| (p.island(), p.point())),
     Ok((island_id, offset + Vec2::new(1.0, 1.0)))
@@ -143,7 +143,7 @@ fn samples_point_on_nav_mesh_or_near_nav_mesh() {
 #[test]
 fn samples_node_types() {
   let mut archipelago =
-    Archipelago::<XY>::new(AgentOptions::default_for_agent_radius(0.5));
+    Archipelago::<XY>::new(AgentOptions::from_agent_radius(0.5));
 
   let node_type_1 = archipelago.add_node_type(1.0).unwrap();
   let node_type_2 = archipelago.add_node_type(2.0).unwrap();
@@ -187,7 +187,7 @@ fn samples_node_types() {
     sample_point(
       &archipelago,
       /* point= */ offset + Vec2::new(0.5, 0.5),
-      /* distance_to_node= */ 0.1
+      /* distance_to_node= */ &0.1
     )
     .map(|p| p.node_type()),
     Ok(None)
@@ -196,7 +196,7 @@ fn samples_node_types() {
     sample_point(
       &archipelago,
       /* point= */ offset + Vec2::new(1.5, 0.5),
-      /* distance_to_node= */ 0.1
+      /* distance_to_node= */ &0.1
     )
     .map(|p| p.node_type()),
     Ok(Some(node_type_1))
@@ -205,7 +205,7 @@ fn samples_node_types() {
     sample_point(
       &archipelago,
       /* point= */ offset + Vec2::new(2.5, 0.5),
-      /* distance_to_node= */ 0.1
+      /* distance_to_node= */ &0.1
     )
     .map(|p| p.node_type()),
     Ok(Some(node_type_2))
@@ -214,7 +214,7 @@ fn samples_node_types() {
     sample_point(
       &archipelago,
       /* point= */ offset + Vec2::new(3.5, 0.5),
-      /* distance_to_node= */ 0.1
+      /* distance_to_node= */ &0.1
     )
     .map(|p| p.node_type()),
     Ok(Some(node_type_3))
@@ -224,7 +224,7 @@ fn samples_node_types() {
 #[test]
 fn no_path() {
   let mut archipelago =
-    Archipelago::<XY>::new(AgentOptions::default_for_agent_radius(0.5));
+    Archipelago::<XY>::new(AgentOptions::from_agent_radius(0.5));
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -255,10 +255,10 @@ fn no_path() {
   archipelago.update(1.0);
 
   let start_point = archipelago
-    .sample_point(offset + Vec2::new(0.5, 0.5), 1e-5)
+    .sample_point(offset + Vec2::new(0.5, 0.5), &1e-5)
     .expect("point is on nav mesh.");
   let end_point = archipelago
-    .sample_point(offset + Vec2::new(2.5, 0.5), 1e-5)
+    .sample_point(offset + Vec2::new(2.5, 0.5), &1e-5)
     .expect("point is on nav mesh.");
   assert_eq!(
     find_path(&archipelago, &start_point, &end_point, &HashMap::new()),
@@ -269,7 +269,7 @@ fn no_path() {
 #[test]
 fn finds_path() {
   let mut archipelago =
-    Archipelago::<XY>::new(AgentOptions::default_for_agent_radius(0.5));
+    Archipelago::<XY>::new(AgentOptions::from_agent_radius(0.5));
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -305,10 +305,10 @@ fn finds_path() {
   archipelago.update(1.0);
 
   let start_point = archipelago
-    .sample_point(offset + Vec2::new(0.5, 0.5), 1e-5)
+    .sample_point(offset + Vec2::new(0.5, 0.5), &1e-5)
     .expect("point is on nav mesh.");
   let end_point = archipelago
-    .sample_point(offset + Vec2::new(2.5, 1.25), 1e-5)
+    .sample_point(offset + Vec2::new(2.5, 1.25), &1e-5)
     .expect("point is on nav mesh.");
   assert_eq!(
     find_path(&archipelago, &start_point, &end_point, &HashMap::new()),
@@ -323,7 +323,7 @@ fn finds_path() {
 #[test]
 fn finds_path_with_override_node_types() {
   let mut archipelago =
-    Archipelago::<XY>::new(AgentOptions::default_for_agent_radius(0.5));
+    Archipelago::<XY>::new(AgentOptions::from_agent_radius(0.5));
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -383,13 +383,13 @@ fn finds_path_with_override_node_types() {
   let start_point = sample_point(
     &archipelago,
     Vec2::new(0.5, 0.5),
-    /* distance_to_node= */ 0.1,
+    /* distance_to_node= */ &0.1,
   )
   .unwrap();
   let end_point = sample_point(
     &archipelago,
     Vec2::new(0.5, 11.5),
-    /* distance_to_node= */ 0.1,
+    /* distance_to_node= */ &0.1,
   )
   .unwrap();
 
@@ -415,7 +415,7 @@ fn finds_path_with_override_node_types() {
 #[test]
 fn find_path_returns_error_on_invalid_node_cost() {
   let mut archipelago =
-    Archipelago::<XY>::new(AgentOptions::default_for_agent_radius(0.5));
+    Archipelago::<XY>::new(AgentOptions::from_agent_radius(0.5));
 
   let nav_mesh = Arc::new(
     NavigationMesh {
@@ -443,10 +443,10 @@ fn find_path_returns_error_on_invalid_node_cost() {
   archipelago.update(1.0);
 
   let start_point = archipelago
-    .sample_point(Vec2::new(0.25, 0.25), /* distance_to_node= */ 0.1)
+    .sample_point(Vec2::new(0.25, 0.25), /* distance_to_node= */ &0.1)
     .unwrap();
   let end_point = archipelago
-    .sample_point(Vec2::new(0.25, 0.25), /* distance_to_node= */ 0.1)
+    .sample_point(Vec2::new(0.25, 0.25), /* distance_to_node= */ &0.1)
     .unwrap();
 
   assert_eq!(

--- a/crates/landmass/src/util.rs
+++ b/crates/landmass/src/util.rs
@@ -89,10 +89,20 @@ impl BoundingBox {
   /// Expands the bounding box by `size`. An empty bounding box will still be
   /// empty after this.
   pub(crate) fn expand_by_size(&self, size: Vec3) -> BoundingBox {
+    self.add_to_corners(-size, size)
+  }
+
+  /// Adds `delta_min` to the min corner, and `delta_max` to the max corner. An
+  /// empty bounding box will still be empty after this.
+  pub(crate) fn add_to_corners(
+    &self,
+    delta_min: Vec3,
+    delta_max: Vec3,
+  ) -> BoundingBox {
     let expanded_box = match self {
       BoundingBox::Empty => BoundingBox::Empty,
       &BoundingBox::Box { min, max } => {
-        BoundingBox::Box { min: min - size, max: max + size }
+        BoundingBox::Box { min: min + delta_min, max: max + delta_max }
       }
     };
 

--- a/crates/landmass_oxidized_navigation/example/main.rs
+++ b/crates/landmass_oxidized_navigation/example/main.rs
@@ -74,7 +74,7 @@ fn setup(
 
   let archipelago_entity = commands
     .spawn((
-      Archipelago3d::new(AgentOptions::default_for_agent_radius(0.5)),
+      Archipelago3d::new(AgentOptions::from_agent_radius(0.5)),
       OxidizedArchipelago,
     ))
     .id();

--- a/crates/landmass_oxidized_navigation/src/lib_test.rs
+++ b/crates/landmass_oxidized_navigation/src/lib_test.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, time::Duration};
 
 use bevy::prelude::*;
-use bevy_landmass::prelude::*;
+use bevy_landmass::{prelude::*, PointSampleDistance3d};
 use bevy_rapier3d::prelude::*;
 use oxidized_navigation::{
   ActiveGenerationTasks, NavMeshAffector, NavMeshSettings,
@@ -42,7 +42,7 @@ fn generates_nav_mesh() {
   let archipelago_entity = app
     .world_mut()
     .spawn((
-      Archipelago3d::new(AgentOptions::default_for_agent_radius(0.5)),
+      Archipelago3d::new(AgentOptions::from_agent_radius(0.5)),
       OxidizedArchipelago,
     ))
     .id();
@@ -71,10 +71,28 @@ fn generates_nav_mesh() {
   let archipelago =
     app.world().get::<Archipelago3d>(archipelago_entity).unwrap();
   let start_point = archipelago
-    .sample_point(Vec3::new(0.0, 0.0, 0.0), /* distance_to_node= */ 0.3)
+    .sample_point(
+      Vec3::new(0.0, 0.0, 0.0),
+      /* distance_to_node= */
+      &PointSampleDistance3d {
+        horizontal_distance: 0.3,
+        distance_above: 0.3,
+        distance_below: 0.3,
+        vertical_preference_ratio: 1.0,
+      },
+    )
     .unwrap();
   let end_point = archipelago
-    .sample_point(Vec3::new(3.0, 0.0, 6.0), /* distance_to_node= */ 0.3)
+    .sample_point(
+      Vec3::new(3.0, 0.0, 6.0),
+      /* distance_to_node= */
+      &PointSampleDistance3d {
+        horizontal_distance: 0.3,
+        distance_above: 0.3,
+        distance_below: 0.3,
+        vertical_preference_ratio: 1.0,
+      },
+    )
     .unwrap();
 
   let path =
@@ -100,10 +118,28 @@ fn generates_nav_mesh() {
   let archipelago =
     app.world().get::<Archipelago3d>(archipelago_entity).unwrap();
   let start_point = archipelago
-    .sample_point(Vec3::new(0.0, 0.0, 0.0), /* distance_to_node= */ 0.3)
+    .sample_point(
+      Vec3::new(0.0, 0.0, 0.0),
+      /* distance_to_node= */
+      &PointSampleDistance3d {
+        horizontal_distance: 0.3,
+        distance_above: 0.3,
+        distance_below: 0.3,
+        vertical_preference_ratio: 1.0,
+      },
+    )
     .unwrap();
   let end_point = archipelago
-    .sample_point(Vec3::new(3.0, 0.0, 6.0), /* distance_to_node= */ 0.3)
+    .sample_point(
+      Vec3::new(3.0, 0.0, 6.0),
+      /* distance_to_node= */
+      &PointSampleDistance3d {
+        horizontal_distance: 0.3,
+        distance_above: 0.3,
+        distance_below: 0.3,
+        vertical_preference_ratio: 1.0,
+      },
+    )
     .unwrap();
 
   let path =


### PR DESCRIPTION
Before we only had one option for changing the sampling - the max distance that a point can be to be sampled. While this worked ok for agents walking from their feet, agents walking from their center of mass could easily sample the wrong point. Similarly, agents going upstairs/downstairs could get confused where it is.

Now, we can filter nodes by their horizontal and vertical distances separately! This means we can have a very small horizontal distance but a large vertical distance - making it much more likely that the nearest point is filtered to ones at the agent's feet. Along these lines, we can also specify how much to prefer vertical distance vs horizontal distance. This means we can prefer entirely vertical points compared to entirely horizontal points, which makes it more likely we pick a point actually at the agent's feet.

The last "feature" is just that `CoordinateSystem`s specify the type of the `PointSampleDistance`. This means only 3D coordinate systems need to worry about all these settings, and 2D can just continue using the same sampling distance as before.