### PR TITLE
Use the "dual-graph" for pathfinding instead of the actual graph.

### DIFF
--- a/crates/bevy_landmass/Cargo.toml
+++ b/crates/bevy_landmass/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_landmass"
 version = "0.9.0"
-edition = "2021"
+edition = "2024"
 
 description = "A plugin for Bevy to handle navigation of AI characters."
 

--- a/crates/bevy_landmass/examples/basic.rs
+++ b/crates/bevy_landmass/examples/basic.rs
@@ -5,10 +5,10 @@ use bevy::{
   prelude::*, render::mesh::Mesh2d,
 };
 use bevy_landmass::{
+  AgentNodeTypeCostOverrides, FromAgentRadius, NavMeshHandle,
   debug::{EnableLandmassDebug, Landmass2dDebugPlugin},
   nav_mesh::bevy_mesh_to_landmass_nav_mesh,
   prelude::*,
-  AgentNodeTypeCostOverrides, FromAgentRadius, NavMeshHandle,
 };
 use landmass::NodeType;
 

--- a/crates/bevy_landmass/src/agent.rs
+++ b/crates/bevy_landmass/src/agent.rs
@@ -8,8 +8,8 @@ use bevy_platform::collections::HashMap;
 use bevy_transform::{components::Transform, helper::TransformHelper};
 
 use crate::{
-  coords::{CoordinateSystem, ThreeD, TwoD},
   AgentState, Archipelago, TargetReachedCondition, Velocity,
+  coords::{CoordinateSystem, ThreeD, TwoD},
 };
 use crate::{ArchipelagoRef, NodeType};
 

--- a/crates/bevy_landmass/src/character.rs
+++ b/crates/bevy_landmass/src/character.rs
@@ -8,8 +8,8 @@ use bevy_platform::collections::HashMap;
 use bevy_transform::{components::Transform, helper::TransformHelper};
 
 use crate::{
-  coords::{CoordinateSystem, ThreeD, TwoD},
   Archipelago, ArchipelagoRef,
+  coords::{CoordinateSystem, ThreeD, TwoD},
 };
 
 /// A bundle to create characters. This omits the GlobalTransform component,

--- a/crates/bevy_landmass/src/debug.rs
+++ b/crates/bevy_landmass/src/debug.rs
@@ -9,9 +9,9 @@ use bevy_ecs::{
   system::{Query, Res},
 };
 use bevy_gizmos::{
+  AppGizmoBuilder,
   config::{GizmoConfig, GizmoConfigGroup},
   gizmos::Gizmos,
-  AppGizmoBuilder,
 };
 use bevy_math::{Isometry3d, Quat};
 use bevy_reflect::Reflect;
@@ -19,8 +19,8 @@ use bevy_time::Time;
 use bevy_transform::components::Transform;
 
 use crate::{
-  coords::{CoordinateSystem, ThreeD, TwoD},
   Archipelago, LandmassSystemSet,
+  coords::{CoordinateSystem, ThreeD, TwoD},
 };
 
 #[cfg(feature = "debug-avoidance")]

--- a/crates/bevy_landmass/src/debug_test.rs
+++ b/crates/bevy_landmass/src/debug_test.rs
@@ -3,16 +3,16 @@ use std::{cmp::Ordering, sync::Arc};
 use bevy_app::App;
 use bevy_asset::{AssetPlugin, Assets};
 use bevy_math::Vec3;
-use bevy_transform::{components::Transform, TransformPlugin};
+use bevy_transform::{TransformPlugin, components::Transform};
 
 use crate::{
-  coords::ThreeD, Agent, Agent3dBundle, AgentOptions, AgentSettings,
-  Archipelago3d, ArchipelagoRef3d, FromAgentRadius, Island, Island3dBundle,
-  Landmass3dPlugin, NavMesh3d, NavMeshHandle, NavigationMesh3d,
+  Agent, Agent3dBundle, AgentOptions, AgentSettings, Archipelago3d,
+  ArchipelagoRef3d, FromAgentRadius, Island, Island3dBundle, Landmass3dPlugin,
+  NavMesh3d, NavMeshHandle, NavigationMesh3d, coords::ThreeD,
 };
 
 use super::{
-  draw_archipelago_debug, DebugDrawer, LineType, PointType, TriangleType,
+  DebugDrawer, LineType, PointType, TriangleType, draw_archipelago_debug,
 };
 
 struct FakeDrawer {
@@ -219,10 +219,10 @@ fn draws_avoidance_data_when_requested() {
   use std::collections::HashMap;
 
   use crate::{
-    debug::{
-      draw_avoidance_data, AvoidanceDrawer, ConstraintKind, ConstraintLine,
-    },
     AgentTarget3d, KeepAvoidanceData, NavigationMesh, Velocity3d,
+    debug::{
+      AvoidanceDrawer, ConstraintKind, ConstraintLine, draw_avoidance_data,
+    },
   };
 
   use bevy::{math::Vec2, prelude::Entity};

--- a/crates/bevy_landmass/src/island.rs
+++ b/crates/bevy_landmass/src/island.rs
@@ -12,8 +12,8 @@ use bevy_platform::collections::{HashMap, HashSet};
 use bevy_transform::{components::Transform, helper::TransformHelper};
 
 use crate::{
-  coords::{CoordinateSystem, ThreeD, TwoD},
   Archipelago, ArchipelagoRef, NavMesh, NavMeshHandle,
+  coords::{CoordinateSystem, ThreeD, TwoD},
 };
 
 /// A bundle to create islands. The GlobalTransform component is omitted, since

--- a/crates/bevy_landmass/src/lib.rs
+++ b/crates/bevy_landmass/src/lib.rs
@@ -39,9 +39,6 @@ pub mod debug;
 pub mod nav_mesh;
 
 pub mod prelude {
-  pub use crate::coords::CoordinateSystem;
-  pub use crate::coords::ThreeD;
-  pub use crate::coords::TwoD;
   pub use crate::Agent2dBundle;
   pub use crate::Agent3dBundle;
   pub use crate::AgentDesiredVelocity2d;
@@ -75,6 +72,9 @@ pub mod prelude {
   pub use crate::ValidNavigationMesh3d;
   pub use crate::Velocity2d;
   pub use crate::Velocity3d;
+  pub use crate::coords::CoordinateSystem;
+  pub use crate::coords::ThreeD;
+  pub use crate::coords::TwoD;
 }
 
 pub struct LandmassPlugin<CS: CoordinateSystem> {

--- a/crates/bevy_landmass/src/lib_test.rs
+++ b/crates/bevy_landmass/src/lib_test.rs
@@ -4,7 +4,7 @@ use bevy_app::App;
 use bevy_asset::{AssetPlugin, Assets};
 use bevy_ecs::entity::Entity;
 use bevy_math::{Quat, Vec2, Vec3};
-use bevy_transform::{components::Transform, TransformPlugin};
+use bevy_transform::{TransformPlugin, components::Transform};
 
 use crate::{
   Agent2dBundle, Agent3dBundle, AgentDesiredVelocity2d, AgentDesiredVelocity3d,

--- a/crates/bevy_landmass/src/nav_mesh.rs
+++ b/crates/bevy_landmass/src/nav_mesh.rs
@@ -1,6 +1,6 @@
 use bevy_mesh::{Indices, Mesh, PrimitiveTopology, VertexAttributeValues};
 
-use crate::{coords::CoordinateSystem, NavigationMesh};
+use crate::{NavigationMesh, coords::CoordinateSystem};
 
 /// A conversion error for Bevy meshes to `landmass` nav meshes.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/landmass/Cargo.toml
+++ b/crates/landmass/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2021"
+edition = "2024"
 name = "landmass"
 version = "0.8.0"
 

--- a/crates/landmass/src/agent.rs
+++ b/crates/landmass/src/agent.rs
@@ -4,9 +4,9 @@ use glam::Vec3;
 use slotmap::new_key_type;
 
 use crate::{
+  CoordinateSystem, IslandId, NavigationData, NodeType,
   nav_data::{BoundaryLinkId, NodeRef},
   path::{Path, PathIndex},
-  CoordinateSystem, IslandId, NavigationData, NodeType,
 };
 
 new_key_type! {

--- a/crates/landmass/src/agent_test.rs
+++ b/crates/landmass/src/agent_test.rs
@@ -8,12 +8,12 @@ use glam::{Vec2, Vec3};
 use slotmap::HopSlotMap;
 
 use crate::{
-  agent::{does_agent_need_repath, RepathResult},
+  Agent, AgentOptions, Archipelago, FromAgentRadius, Island, IslandId,
+  NavigationMesh, NodeType, TargetReachedCondition, Transform,
+  agent::{RepathResult, does_agent_need_repath},
   coords::{XY, XYZ},
   nav_data::NodeRef,
   path::{IslandSegment, Path, PathIndex},
-  Agent, AgentOptions, Archipelago, FromAgentRadius, Island, IslandId,
-  NavigationMesh, NodeType, TargetReachedCondition, Transform,
 };
 
 #[test]

--- a/crates/landmass/src/astar_test.rs
+++ b/crates/landmass/src/astar_test.rs
@@ -1,4 +1,4 @@
-use super::{find_path, AStarProblem};
+use super::{AStarProblem, find_path};
 
 struct AdjacencyListProblemState {
   adjacency: Vec<(f32, i32, usize)>,

--- a/crates/landmass/src/avoidance.rs
+++ b/crates/landmass/src/avoidance.rs
@@ -2,13 +2,13 @@ use std::collections::{BinaryHeap, HashMap, HashSet};
 
 use dodgy_2d::VisibilitySet;
 use glam::{Vec3, Vec3Swizzles};
-use kdtree::{distance::squared_euclidean, KdTree};
+use kdtree::{KdTree, distance::squared_euclidean};
 use slotmap::HopSlotMap;
 
 use crate::{
-  nav_data::{ModifiedNode, NodeRef},
   Agent, AgentId, AgentOptions, AgentState, Character, CharacterId,
   CoordinateSystem, Island, IslandId, NavigationData,
+  nav_data::{ModifiedNode, NodeRef},
 };
 
 /// Adjusts the velocity of `agents` to apply local avoidance. `delta_time` must

--- a/crates/landmass/src/avoidance_test.rs
+++ b/crates/landmass/src/avoidance_test.rs
@@ -915,6 +915,8 @@ fn switching_nav_mesh_to_fewer_vertices_does_not_result_in_panic() {
     agent
   });
 
+  // Update twice to allow the velocity to "stabilize".
+  archipelago.update(0.01);
   archipelago.update(0.01);
 
   // This doesn't really matter for the test, but ensures that pathing +

--- a/crates/landmass/src/avoidance_test.rs
+++ b/crates/landmass/src/avoidance_test.rs
@@ -4,11 +4,11 @@ use glam::{Vec2, Vec3};
 use slotmap::HopSlotMap;
 
 use crate::{
+  Agent, AgentId, AgentOptions, Archipelago, Character, CharacterId,
+  FromAgentRadius, Island, NavigationData, NavigationMesh, Transform,
   avoidance::apply_avoidance_to_agents,
   coords::{XY, XYZ},
   nav_data::NodeRef,
-  Agent, AgentId, AgentOptions, Archipelago, Character, CharacterId,
-  FromAgentRadius, Island, NavigationData, NavigationMesh, Transform,
 };
 
 use super::nav_mesh_borders_to_dodgy_obstacles;

--- a/crates/landmass/src/debug.rs
+++ b/crates/landmass/src/debug.rs
@@ -1,8 +1,8 @@
 use thiserror::Error;
 
 use crate::{
-  nav_data::NodeRef, path::Path, Agent, AgentId, Archipelago, CoordinateSystem,
-  Island,
+  Agent, AgentId, Archipelago, CoordinateSystem, Island, nav_data::NodeRef,
+  path::Path,
 };
 
 #[cfg(feature = "debug-avoidance")]
@@ -59,7 +59,9 @@ pub trait DebugDrawer<CS: CoordinateSystem> {
 /// An error resulting from trying to debug draw an archipelago.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Error)]
 pub enum DebugDrawError {
-  #[error("The navigation data of the archipelago has been mutated since the last update.")]
+  #[error(
+    "The navigation data of the archipelago has been mutated since the last update."
+  )]
   NavDataDirty,
 }
 
@@ -81,7 +83,10 @@ pub fn draw_archipelago_debug<CS: CoordinateSystem>(
 
   for island_id in archipelago.get_island_ids() {
     let island = archipelago.get_island(island_id).unwrap();
-    assert!(!island.dirty, "Drawing an archipelago while things are dirty is unsafe! Update the archipelago first.");
+    assert!(
+      !island.dirty,
+      "Drawing an archipelago while things are dirty is unsafe! Update the archipelago first."
+    );
     for (polygon_index, polygon) in island.nav_mesh.polygons.iter().enumerate()
     {
       let center_point = island.transform.apply(polygon.center);

--- a/crates/landmass/src/debug_test.rs
+++ b/crates/landmass/src/debug_test.rs
@@ -3,10 +3,10 @@ use std::{cmp::Ordering, collections::HashMap, sync::Arc};
 use glam::Vec3;
 
 use crate::{
-  coords::XYZ,
-  debug::{DebugDrawError, DebugDrawer, LineType, PointType, TriangleType},
   Agent, AgentOptions, Archipelago, FromAgentRadius, Island, NavigationMesh,
   Transform,
+  coords::XYZ,
+  debug::{DebugDrawError, DebugDrawer, LineType, PointType, TriangleType},
 };
 
 use super::draw_archipelago_debug;
@@ -516,10 +516,10 @@ fn draws_avoidance_data_when_requested() {
   use googletest::{matcher::MatcherResult, prelude::*};
 
   use crate::{
-    debug::{
-      draw_avoidance_data, AvoidanceDrawer, ConstraintKind, ConstraintLine,
-    },
     AgentId,
+    debug::{
+      AvoidanceDrawer, ConstraintKind, ConstraintLine, draw_avoidance_data,
+    },
   };
 
   let nav_mesh = Arc::new(

--- a/crates/landmass/src/island.rs
+++ b/crates/landmass/src/island.rs
@@ -3,8 +3,8 @@ use std::{collections::HashMap, sync::Arc};
 use slotmap::new_key_type;
 
 use crate::{
-  util::{BoundingBox, Transform},
   CoordinateSystem, NodeType, ValidNavigationMesh,
+  util::{BoundingBox, Transform},
 };
 
 new_key_type! {

--- a/crates/landmass/src/lib.rs
+++ b/crates/landmass/src/lib.rs
@@ -14,7 +14,7 @@ mod pathfinding;
 mod query;
 mod util;
 
-use agent::{does_agent_need_repath, RepathResult};
+use agent::{RepathResult, does_agent_need_repath};
 use glam::Vec3Swizzles;
 use path::PathIndex;
 use slotmap::HopSlotMap;

--- a/crates/landmass/src/lib.rs
+++ b/crates/landmass/src/lib.rs
@@ -288,16 +288,12 @@ impl<CS: CoordinateSystem> Archipelago<CS> {
     let mut agent_id_to_follow_path_indices = HashMap::new();
 
     for (agent_id, agent) in self.agents.iter_mut() {
-      let agent_node = agent_id_to_agent_node
-        .get(&agent_id)
-        .map(|node_and_point| node_and_point.1);
-      let target_node = agent_id_to_target_node
-        .get(&agent_id)
-        .map(|node_and_point| node_and_point.1);
+      let agent_point_and_node = agent_id_to_agent_node.get(&agent_id);
+      let target_point_and_node = agent_id_to_target_node.get(&agent_id);
       match does_agent_need_repath(
         agent,
-        agent_node,
-        target_node,
+        agent_point_and_node.map(|(_, node)| *node),
+        target_point_and_node.map(|(_, node)| *node),
         &invalidated_boundary_links,
         &invalidated_islands,
       ) {
@@ -326,10 +322,14 @@ impl<CS: CoordinateSystem> Archipelago<CS> {
         RepathResult::NeedsRepath => {
           agent.current_path = None;
 
+          let (agent_point, agent_node) = agent_point_and_node.unwrap();
+          let (target_point, target_node) = target_point_and_node.unwrap();
           let path_result = pathfinding::find_path(
             &self.nav_data,
-            agent_node.unwrap(),
-            target_node.unwrap(),
+            *agent_node,
+            *agent_point,
+            *target_node,
+            *target_point,
             &agent.override_node_type_to_cost,
           );
 

--- a/crates/landmass/src/lib_test.rs
+++ b/crates/landmass/src/lib_test.rs
@@ -3,10 +3,10 @@ use std::{collections::HashMap, sync::Arc};
 use glam::{Vec2, Vec3};
 
 use crate::{
-  coords::{XY, XYZ},
   Agent, AgentId, AgentOptions, AgentState, Archipelago, Character,
   CharacterId, FromAgentRadius, Island, IslandId, NavigationMesh,
   PointSampleDistance3d, Transform,
+  coords::{XY, XYZ},
 };
 
 #[test]
@@ -272,16 +272,20 @@ fn computes_and_follows_path() {
     archipelago.get_agent(agent_2).unwrap().state(),
     AgentState::Moving
   );
-  assert!(archipelago
-    .get_agent(agent_1)
-    .unwrap()
-    .get_desired_velocity()
-    .abs_diff_eq(Vec3::new(1.5, 0.5, 0.0).normalize() * 2.0, 1e-2));
-  assert!(archipelago
-    .get_agent(agent_2)
-    .unwrap()
-    .get_desired_velocity()
-    .abs_diff_eq(Vec3::new(-0.5, -1.5, 0.0).normalize() * 2.0, 1e-2));
+  assert!(
+    archipelago
+      .get_agent(agent_1)
+      .unwrap()
+      .get_desired_velocity()
+      .abs_diff_eq(Vec3::new(1.5, 0.5, 0.0).normalize() * 2.0, 1e-2)
+  );
+  assert!(
+    archipelago
+      .get_agent(agent_2)
+      .unwrap()
+      .get_desired_velocity()
+      .abs_diff_eq(Vec3::new(-0.5, -1.5, 0.0).normalize() * 2.0, 1e-2)
+  );
   // These agents are not on the nav mesh, so they don't do anything.
   assert_eq!(
     archipelago.get_agent(agent_off_mesh).unwrap().state(),
@@ -316,17 +320,21 @@ fn computes_and_follows_path() {
     Vec3::new(2.5, 1.5, 1.0);
   archipelago.update(/* delta_time= */ 0.01);
 
-  assert!(archipelago
-    .get_agent(agent_1)
-    .unwrap()
-    .get_desired_velocity()
-    .abs_diff_eq(Vec3::new(0.5, 0.5, 0.0).normalize() * 2.0, 1e-7));
+  assert!(
+    archipelago
+      .get_agent(agent_1)
+      .unwrap()
+      .get_desired_velocity()
+      .abs_diff_eq(Vec3::new(0.5, 0.5, 0.0).normalize() * 2.0, 1e-7)
+  );
   // These agents don't change.
-  assert!(archipelago
-    .get_agent(agent_2)
-    .unwrap()
-    .get_desired_velocity()
-    .abs_diff_eq(Vec3::new(-0.5, -1.5, 0.0).normalize() * 2.0, 1e-2));
+  assert!(
+    archipelago
+      .get_agent(agent_2)
+      .unwrap()
+      .get_desired_velocity()
+      .abs_diff_eq(Vec3::new(-0.5, -1.5, 0.0).normalize() * 2.0, 1e-2)
+  );
   assert_eq!(
     *archipelago.get_agent(agent_off_mesh).unwrap().get_desired_velocity(),
     Vec3::ZERO
@@ -374,11 +382,13 @@ fn computes_and_follows_path() {
     *archipelago.get_agent(agent_1).unwrap().get_desired_velocity(),
     Vec3::ZERO
   );
-  assert!(archipelago
-    .get_agent(agent_2)
-    .unwrap()
-    .get_desired_velocity()
-    .abs_diff_eq(Vec3::new(-0.5, -0.5, 0.0).normalize() * 2.0, 1e-2));
+  assert!(
+    archipelago
+      .get_agent(agent_2)
+      .unwrap()
+      .get_desired_velocity()
+      .abs_diff_eq(Vec3::new(-0.5, -0.5, 0.0).normalize() * 2.0, 1e-2)
+  );
   // These agents don't change.
   assert_eq!(
     *archipelago.get_agent(agent_off_mesh).unwrap().get_desired_velocity(),

--- a/crates/landmass/src/nav_data.rs
+++ b/crates/landmass/src/nav_data.rs
@@ -82,11 +82,6 @@ pub(crate) struct BoundaryLink {
   /// This is essentially the intersection of the linked islands' linkable
   /// edges.
   pub(crate) portal: (Vec3, Vec3),
-  /// The distances of travelling across this link. The first is the distance
-  /// travelled across the starting node, and the second is the
-  /// distance travelled across the destination node. These must be multiplied
-  /// by the actual node costs.
-  pub(crate) travel_distances: (f32, f32),
 }
 
 /// A node that has been modified (e.g., by being connected with a boundary link
@@ -814,15 +809,6 @@ fn link_edges_between_islands<CS: CoordinateSystem>(
         let polygon_2 =
           &island_2.nav_mesh.polygons[island_2_edge_ref.polygon_index];
 
-        let polygon_center_1 = island_1.transform.apply(polygon_1.center);
-        let polygon_center_2 = island_2.transform.apply(polygon_2.center);
-        let portal_center = (portal.0 + portal.1) / 2.0;
-
-        let travel_distances = (
-          polygon_center_1.distance(portal_center),
-          polygon_center_2.distance(portal_center),
-        );
-
         let node_type_1 =
           island_1.type_index_to_node_type.get(&polygon_1.type_index).copied();
         let node_type_2 =
@@ -832,13 +818,11 @@ fn link_edges_between_islands<CS: CoordinateSystem>(
           destination_node: node_2,
           destination_node_type: node_type_2,
           portal,
-          travel_distances,
         });
         let id_2 = boundary_links.insert(BoundaryLink {
           destination_node: node_1,
           destination_node_type: node_type_1,
           portal: (portal.1, portal.0),
-          travel_distances: (travel_distances.1, travel_distances.0),
         });
 
         node_to_boundary_link_ids.entry(node_1).or_default().insert(id_1);

--- a/crates/landmass/src/nav_data.rs
+++ b/crates/landmass/src/nav_data.rs
@@ -80,7 +80,7 @@ pub(crate) struct BoundaryLink {
   pub(crate) destination_node_type: Option<NodeType>,
   /// The portal that this link occupies on the boundary of the source node.
   /// This is essentially the intersection of the linked islands' linkable
-  /// edges.
+  /// edges. The portal is in world-space.
   pub(crate) portal: (Vec3, Vec3),
 }
 

--- a/crates/landmass/src/nav_data_test.rs
+++ b/crates/landmass/src/nav_data_test.rs
@@ -9,17 +9,17 @@ use glam::{Vec2, Vec3};
 use slotmap::{HopSlotMap, SlotMap};
 
 use crate::{
+  AgentOptions, Archipelago, FromAgentRadius, IslandId, NewNodeTypeError,
+  NodeType, PointSampleDistance3d, SetNodeTypeCostError, Transform,
   coords::{XY, XYZ},
   island::Island,
   nav_data::{BoundaryLink, NodeRef},
   nav_mesh::NavigationMesh,
-  AgentOptions, Archipelago, FromAgentRadius, IslandId, NewNodeTypeError,
-  NodeType, PointSampleDistance3d, SetNodeTypeCostError, Transform,
 };
 
 use super::{
-  island_edges_bbh, link_edges_between_islands, BoundaryLinkId, ModifiedNode,
-  NavigationData,
+  BoundaryLinkId, ModifiedNode, NavigationData, island_edges_bbh,
+  link_edges_between_islands,
 };
 
 #[test]
@@ -148,6 +148,9 @@ fn clone_sort_round_links(
               (link.portal.0 / round_amount).round() * round_amount,
               (link.portal.1 / round_amount).round() * round_amount,
             ),
+            // We can't store the right link IDs anyway, so just make it
+            // default.
+            reverse_link: BoundaryLinkId::default(),
           })
           .collect::<Vec<_>>();
         v.sort_by_key(|link| {
@@ -284,6 +287,7 @@ fn link_edges_between_islands_links_touching_islands() {
           Vec3::new(1.0, 0.5, 1.0),
           Vec3::new(1.0, 0.0, 1.0),
         ),
+        reverse_link: Default::default(),
       }],
     ),
     (
@@ -296,6 +300,7 @@ fn link_edges_between_islands_links_touching_islands() {
           Vec3::new(-0.5, 1.0, 1.0),
           Vec3::new(0.5, 1.0, 1.0),
         ),
+        reverse_link: Default::default(),
       }],
     ),
     (
@@ -308,6 +313,7 @@ fn link_edges_between_islands_links_touching_islands() {
           Vec3::new(-1.0, 0.0, 1.0),
           Vec3::new(-1.0, 0.5, 1.0),
         ),
+        reverse_link: Default::default(),
       }],
     ),
     (
@@ -320,6 +326,7 @@ fn link_edges_between_islands_links_touching_islands() {
           Vec3::new(-1.0, -0.5, 1.0),
           Vec3::new(-1.0, 0.0, 1.0),
         ),
+        reverse_link: Default::default(),
       }],
     ),
     (
@@ -332,6 +339,7 @@ fn link_edges_between_islands_links_touching_islands() {
           Vec3::new(0.5, -1.0, 1.0),
           Vec3::new(-0.5, -1.0, 1.0),
         ),
+        reverse_link: Default::default(),
       }],
     ),
     (
@@ -344,6 +352,7 @@ fn link_edges_between_islands_links_touching_islands() {
           Vec3::new(1.0, 0.0, 1.0),
           Vec3::new(1.0, -0.5, 1.0),
         ),
+        reverse_link: Default::default(),
       }],
     ),
     // Reverse links
@@ -361,6 +370,7 @@ fn link_edges_between_islands_links_touching_islands() {
             Vec3::new(-1.0, 0.5, 1.0),
             Vec3::new(-1.0, 0.0, 1.0),
           ),
+          reverse_link: Default::default(),
         },
         BoundaryLink {
           destination_node: NodeRef {
@@ -373,6 +383,7 @@ fn link_edges_between_islands_links_touching_islands() {
             Vec3::new(-1.0, 0.0, 1.0),
             Vec3::new(-1.0, -0.5, 1.0),
           ),
+          reverse_link: Default::default(),
         },
       ],
     ),
@@ -390,6 +401,7 @@ fn link_edges_between_islands_links_touching_islands() {
             Vec3::new(1.0, 0.0, 1.0),
             Vec3::new(1.0, 0.5, 1.0),
           ),
+          reverse_link: Default::default(),
         },
         BoundaryLink {
           destination_node: NodeRef {
@@ -402,6 +414,7 @@ fn link_edges_between_islands_links_touching_islands() {
             Vec3::new(1.0, -0.5, 1.0),
             Vec3::new(1.0, 0.0, 1.0),
           ),
+          reverse_link: Default::default(),
         },
       ],
     ),
@@ -415,6 +428,7 @@ fn link_edges_between_islands_links_touching_islands() {
           Vec3::new(0.5, 1.0, 1.0),
           Vec3::new(-0.5, 1.0, 1.0),
         ),
+        reverse_link: Default::default(),
       }],
     ),
     (
@@ -427,6 +441,7 @@ fn link_edges_between_islands_links_touching_islands() {
           Vec3::new(-0.5, -1.0, 1.0),
           Vec3::new(0.5, -1.0, 1.0),
         ),
+        reverse_link: Default::default(),
       }],
     ),
   ];
@@ -551,6 +566,7 @@ fn update_links_islands_and_unlinks_on_delete() {
             },
             destination_node_type: None,
             portal: (Vec3::new(1.0, 0.0, 1.0), Vec3::new(2.0, 0.0, 1.0)),
+            reverse_link: Default::default(),
           },
           BoundaryLink {
             destination_node: NodeRef {
@@ -559,6 +575,7 @@ fn update_links_islands_and_unlinks_on_delete() {
             },
             destination_node_type: None,
             portal: (Vec3::new(2.0, 1.0, 1.0), Vec3::new(2.0, 2.0, 1.0)),
+            reverse_link: Default::default(),
           },
         ],
       ),
@@ -571,6 +588,7 @@ fn update_links_islands_and_unlinks_on_delete() {
           },
           destination_node_type: None,
           portal: (Vec3::new(0.0, 2.0, 1.0), Vec3::new(0.0, 1.0, 1.0)),
+          reverse_link: Default::default(),
         }],
       ),
       (
@@ -582,6 +600,7 @@ fn update_links_islands_and_unlinks_on_delete() {
           },
           destination_node_type: None,
           portal: (Vec3::new(0.0, 1.0, 1.0), Vec3::new(0.0, 2.0, 1.0)),
+          reverse_link: Default::default(),
         }],
       ),
       (
@@ -593,6 +612,7 @@ fn update_links_islands_and_unlinks_on_delete() {
           },
           destination_node_type: None,
           portal: (Vec3::new(-2.0, 0.0, 1.0), Vec3::new(-1.0, 0.0, 1.0)),
+          reverse_link: Default::default(),
         }],
       ),
       (
@@ -604,6 +624,7 @@ fn update_links_islands_and_unlinks_on_delete() {
           },
           destination_node_type: None,
           portal: (Vec3::new(-1.0, 0.0, 1.0), Vec3::new(-2.0, 0.0, 1.0)),
+          reverse_link: Default::default(),
         }],
       ),
       (
@@ -615,6 +636,7 @@ fn update_links_islands_and_unlinks_on_delete() {
           },
           destination_node_type: None,
           portal: (Vec3::new(2.0, 0.0, 1.0), Vec3::new(1.0, 0.0, 1.0)),
+          reverse_link: Default::default(),
         }],
       ),
       (
@@ -626,6 +648,7 @@ fn update_links_islands_and_unlinks_on_delete() {
           },
           destination_node_type: None,
           portal: (Vec3::new(2.0, 2.0, 1.0), Vec3::new(2.0, 1.0, 1.0)),
+          reverse_link: Default::default(),
         }],
       ),
     ],
@@ -660,6 +683,7 @@ fn update_links_islands_and_unlinks_on_delete() {
           },
           destination_node_type: None,
           portal: (Vec3::new(0.0, 2.0, 1.0), Vec3::new(0.0, 1.0, 1.0)),
+          reverse_link: Default::default(),
         }],
       ),
       (
@@ -671,6 +695,7 @@ fn update_links_islands_and_unlinks_on_delete() {
           },
           destination_node_type: None,
           portal: (Vec3::new(-1.0, 0.0, 1.0), Vec3::new(-2.0, 0.0, 1.0)),
+          reverse_link: Default::default(),
         }],
       ),
       (
@@ -682,6 +707,7 @@ fn update_links_islands_and_unlinks_on_delete() {
           },
           destination_node_type: None,
           portal: (Vec3::new(0.0, 1.0, 1.0), Vec3::new(0.0, 2.0, 1.0)),
+          reverse_link: Default::default(),
         }],
       ),
       (
@@ -693,6 +719,7 @@ fn update_links_islands_and_unlinks_on_delete() {
           },
           destination_node_type: None,
           portal: (Vec3::new(-2.0, 0.0, 1.0), Vec3::new(-1.0, 0.0, 1.0)),
+          reverse_link: Default::default(),
         }],
       ),
     ],

--- a/crates/landmass/src/nav_mesh.rs
+++ b/crates/landmass/src/nav_mesh.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use disjoint::DisjointSet;
-use glam::{swizzles::Vec3Swizzles, Vec3};
+use glam::{Vec3, swizzles::Vec3Swizzles};
 use thiserror::Error;
 
 use crate::{
@@ -61,7 +61,9 @@ pub enum ValidationError {
   #[error("The polygon at index {0} references an out-of-bounds vertex.")]
   InvalidVertexIndexInPolygon(usize),
   /// Stores the index of the polygon.
-  #[error("The polygon at index {0} contains a degenerate edge (an edge with zero length).")]
+  #[error(
+    "The polygon at index {0} contains a degenerate edge (an edge with zero length)."
+  )]
   DegenerateEdgeInPolygon(usize),
   /// Stores the indices of the two vertices that make up the edge.
   #[error(

--- a/crates/landmass/src/nav_mesh.rs
+++ b/crates/landmass/src/nav_mesh.rs
@@ -367,15 +367,8 @@ impl<CS: CoordinateSystem> ValidNavigationMesh<CS> {
   // Gets the points that make up the specified edge.
   pub(crate) fn get_edge_points(&self, edge_ref: MeshEdgeRef) -> (Vec3, Vec3) {
     let polygon = &self.polygons[edge_ref.polygon_index];
-    let left_vertex_index = polygon.vertices[edge_ref.edge_index];
-
-    let right_vertex_index =
-      if edge_ref.edge_index == polygon.vertices.len() - 1 {
-        0
-      } else {
-        edge_ref.edge_index + 1
-      };
-    let right_vertex_index = polygon.vertices[right_vertex_index];
+    let (left_vertex_index, right_vertex_index) =
+      polygon.get_edge_indices(edge_ref.edge_index);
 
     (self.vertices[left_vertex_index], self.vertices[right_vertex_index])
   }

--- a/crates/landmass/src/nav_mesh.rs
+++ b/crates/landmass/src/nav_mesh.rs
@@ -240,17 +240,13 @@ impl<CS: CoordinateSystem> NavigationMesh<CS> {
           polygon_2,
           edge_2,
         } => {
-          let edge = polygons[polygon_1].get_edge_indices(edge_1);
-          let edge_center = (vertices[edge.0] + vertices[edge.1]) / 2.0;
-          let travel_distances = (
-            polygons[polygon_1].center.distance(edge_center),
-            polygons[polygon_2].center.distance(edge_center),
-          );
-          polygons[polygon_1].connectivity[edge_1] =
-            Some(Connectivity { polygon_index: polygon_2, travel_distances });
+          polygons[polygon_1].connectivity[edge_1] = Some(Connectivity {
+            polygon_index: polygon_2,
+            reverse_edge: edge_2,
+          });
           polygons[polygon_2].connectivity[edge_2] = Some(Connectivity {
             polygon_index: polygon_1,
-            travel_distances: (travel_distances.1, travel_distances.0),
+            reverse_edge: edge_1,
           });
         }
       }
@@ -349,11 +345,8 @@ pub(crate) struct ValidPolygon {
 pub(crate) struct Connectivity {
   /// The index of the polygon that this edge leads to.
   pub(crate) polygon_index: usize,
-  /// The distances of travelling across this connection. The first is the
-  /// distance travelled across the starting node, and the second is the
-  /// distance travelled across the destination node. These must be multiplied
-  /// by the actual node costs.
-  pub(crate) travel_distances: (f32, f32),
+  /// The index of the edge that would take us back to the original node.
+  pub(crate) reverse_edge: usize,
 }
 
 /// A reference to an edge on a navigation mesh.

--- a/crates/landmass/src/nav_mesh_test.rs
+++ b/crates/landmass/src/nav_mesh_test.rs
@@ -3,10 +3,10 @@ use std::collections::HashSet;
 use glam::Vec3;
 
 use crate::{
+  PointSampleDistance3d,
   coords::XYZ,
   nav_mesh::{Connectivity, MeshEdgeRef, ValidPolygon},
   util::BoundingBox,
-  PointSampleDistance3d,
 };
 
 use super::{NavigationMesh, ValidationError};

--- a/crates/landmass/src/nav_mesh_test.rs
+++ b/crates/landmass/src/nav_mesh_test.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use glam::{Vec2, Vec3};
+use glam::Vec3;
 
 use crate::{
   coords::XYZ,
@@ -293,55 +293,22 @@ fn derives_connectivity_and_boundary_edges() {
     boundary_edge.polygon_index * 100 + boundary_edge.edge_index
   });
 
-  // Each edge has a cost of node 1 to its edge (always 0.5), and each other
-  // node to its edge.
-  let travel_distances_01 =
-    (Vec2::new(2.0 / 3.0, 1.0 / 3.0).distance(Vec2::new(1.0, 0.5)), 0.5);
-  let travel_distances_12 =
-    (0.5, Vec3::new(2.5, 0.5, 0.5).distance(Vec3::new(2.0, 0.5, 0.0)));
-  let travel_distances_13 =
-    (0.5, Vec3::new(1.5, 1.5, 0.5).distance(Vec3::new(1.5, 1.0, 0.0)));
-
-  let flip = |(a, b): (f32, f32)| (b, a);
-
   let expected_connectivity: [&[_]; 4] = [
+    &[None, Some(Connectivity { polygon_index: 1, reverse_edge: 3 }), None],
     &[
       None,
-      Some(Connectivity {
-        polygon_index: 1,
-        travel_distances: travel_distances_01,
-      }),
-      None,
-    ],
-    &[
-      None,
-      Some(Connectivity {
-        polygon_index: 2,
-        travel_distances: travel_distances_12,
-      }),
-      Some(Connectivity {
-        polygon_index: 3,
-        travel_distances: travel_distances_13,
-      }),
-      Some(Connectivity {
-        polygon_index: 0,
-        travel_distances: flip(travel_distances_01),
-      }),
+      Some(Connectivity { polygon_index: 2, reverse_edge: 3 }),
+      Some(Connectivity { polygon_index: 3, reverse_edge: 0 }),
+      Some(Connectivity { polygon_index: 0, reverse_edge: 1 }),
     ],
     &[
       None,
       None,
       None,
-      Some(Connectivity {
-        polygon_index: 1,
-        travel_distances: flip(travel_distances_12),
-      }),
+      Some(Connectivity { polygon_index: 1, reverse_edge: 1 }),
     ],
     &[
-      Some(Connectivity {
-        polygon_index: 1,
-        travel_distances: flip(travel_distances_13),
-      }),
+      Some(Connectivity { polygon_index: 1, reverse_edge: 2 }),
       None,
       None,
       None,

--- a/crates/landmass/src/path.rs
+++ b/crates/landmass/src/path.rs
@@ -3,8 +3,8 @@ use std::{cmp::Ordering, collections::HashSet};
 use glam::{Vec3, Vec3Swizzles};
 
 use crate::{
-  nav_data::{BoundaryLinkId, NodeRef},
   CoordinateSystem, IslandId, NavigationData,
+  nav_data::{BoundaryLinkId, NodeRef},
 };
 
 /// A path computed on the navigation data.

--- a/crates/landmass/src/path_test.rs
+++ b/crates/landmass/src/path_test.rs
@@ -8,12 +8,12 @@ use glam::{Vec2, Vec3};
 use slotmap::HopSlotMap;
 
 use crate::{
+  AgentOptions, Archipelago, CoordinateSystem, FromAgentRadius, Island,
+  IslandId, Transform,
   coords::{XY, XYZ},
   nav_data::{BoundaryLinkId, NavigationData, NodeRef},
   nav_mesh::NavigationMesh,
   path::{BoundaryLinkSegment, IslandSegment},
-  AgentOptions, Archipelago, CoordinateSystem, FromAgentRadius, Island,
-  IslandId, Transform,
 };
 
 use super::{Path, PathIndex};

--- a/crates/landmass/src/pathfinding.rs
+++ b/crates/landmass/src/pathfinding.rs
@@ -122,8 +122,7 @@ impl<CS: CoordinateSystem> AStarProblem for ArchipelagoPathProblem<'_, CS> {
         if !destination_node_cost.is_finite() {
           return None;
         }
-        let cost = link.travel_distances.0 * current_node_cost
-          + link.travel_distances.1 * destination_node_cost;
+        let cost = todo!();
         Some((cost, PathStep::BoundaryLink(*link_id), link.destination_node))
       }))
       .collect()

--- a/crates/landmass/src/pathfinding.rs
+++ b/crates/landmass/src/pathfinding.rs
@@ -241,11 +241,14 @@ pub(crate) struct PathResult {
 
 /// Finds a path in `nav_data` from `start_node` to `end_node`. Node costs are
 /// overriden with `override_node_type_to_cost`. Returns an `Err` if no path was
-/// found.
+/// found. `start_point` and `end_point` are assumed to be in the corresponding
+/// nodes, and in world space.
 pub(crate) fn find_path<CS: CoordinateSystem>(
   nav_data: &NavigationData<CS>,
   start_node: NodeRef,
+  start_point: Vec3,
   end_node: NodeRef,
+  end_point: Vec3,
   override_node_type_to_cost: &HashMap<NodeType, f32>,
 ) -> PathResult {
   if !nav_data.are_nodes_connected(start_node, end_node) {
@@ -256,18 +259,8 @@ pub(crate) fn find_path<CS: CoordinateSystem>(
     nav_data,
     start_node,
     end_node,
-    start_point: {
-      let island = nav_data.get_island(start_node.island_id).unwrap();
-      island
-        .transform
-        .apply(island.nav_mesh.polygons[start_node.polygon_index].center)
-    },
-    end_point: {
-      let island = nav_data.get_island(end_node.island_id).unwrap();
-      island
-        .transform
-        .apply(island.nav_mesh.polygons[end_node.polygon_index].center)
-    },
+    start_point,
+    end_point,
     cheapest_node_type_cost: *nav_data
       .get_node_types()
       .map(|(node_type, cost)| {

--- a/crates/landmass/src/pathfinding.rs
+++ b/crates/landmass/src/pathfinding.rs
@@ -104,8 +104,7 @@ impl<CS: CoordinateSystem> AStarProblem for ArchipelagoPathProblem<'_, CS> {
           return None;
         }
 
-        let cost = conn.travel_distances.0 * current_node_cost
-          + conn.travel_distances.1 * target_node_cost;
+        let cost = todo!();
 
         Some((
           cost,

--- a/crates/landmass/src/pathfinding_test.rs
+++ b/crates/landmass/src/pathfinding_test.rs
@@ -3,13 +3,13 @@ use std::{collections::HashMap, f32::consts::PI, sync::Arc};
 use glam::{Vec2, Vec3};
 
 use crate::{
+  AgentOptions, Archipelago, CoordinateSystem, FromAgentRadius, Island,
+  NodeType, Transform,
   coords::{XY, XYZ},
   nav_data::{NavigationData, NodeRef},
   nav_mesh::NavigationMesh,
   path::{BoundaryLinkSegment, IslandSegment, Path},
   pathfinding::PathResult,
-  AgentOptions, Archipelago, CoordinateSystem, FromAgentRadius, Island,
-  NodeType, Transform,
 };
 
 use super::find_path;
@@ -272,23 +272,27 @@ fn no_path_between_disconnected_islands() {
 
   let nav_data = &archipelago.nav_data;
 
-  assert!(find_path_between_nodes(
-    nav_data,
-    NodeRef { island_id: island_id_1, polygon_index: 0 },
-    NodeRef { island_id: island_id_2, polygon_index: 0 },
-    &HashMap::new(),
-  )
-  .path
-  .is_none());
+  assert!(
+    find_path_between_nodes(
+      nav_data,
+      NodeRef { island_id: island_id_1, polygon_index: 0 },
+      NodeRef { island_id: island_id_2, polygon_index: 0 },
+      &HashMap::new(),
+    )
+    .path
+    .is_none()
+  );
 
-  assert!(find_path_between_nodes(
-    nav_data,
-    NodeRef { island_id: island_id_2, polygon_index: 0 },
-    NodeRef { island_id: island_id_1, polygon_index: 0 },
-    &HashMap::new(),
-  )
-  .path
-  .is_none());
+  assert!(
+    find_path_between_nodes(
+      nav_data,
+      NodeRef { island_id: island_id_2, polygon_index: 0 },
+      NodeRef { island_id: island_id_1, polygon_index: 0 },
+      &HashMap::new(),
+    )
+    .path
+    .is_none()
+  );
 }
 
 #[test]
@@ -532,14 +536,16 @@ fn aborts_early_for_unconnected_regions() {
   archipelago.update(1.0);
 
   // Verify that with island_id_3, the islands are connected.
-  assert!(find_path_between_nodes(
-    &archipelago.nav_data,
-    NodeRef { island_id: island_id_1, polygon_index: 0 },
-    NodeRef { island_id: island_id_2, polygon_index: 0 },
-    &HashMap::new(),
-  )
-  .path
-  .is_some());
+  assert!(
+    find_path_between_nodes(
+      &archipelago.nav_data,
+      NodeRef { island_id: island_id_1, polygon_index: 0 },
+      NodeRef { island_id: island_id_2, polygon_index: 0 },
+      &HashMap::new(),
+    )
+    .path
+    .is_some()
+  );
 
   // Remove island_id_3 which will disconnect the other two islands.
   archipelago.remove_island(island_id_3);
@@ -553,8 +559,10 @@ fn aborts_early_for_unconnected_regions() {
   );
 
   assert!(path_result.path.is_none());
-  assert_eq!(path_result.stats.explored_nodes, 0,
-    "No nodes should have been explored since the regions are completely disconnected.");
+  assert_eq!(
+    path_result.stats.explored_nodes, 0,
+    "No nodes should have been explored since the regions are completely disconnected."
+  );
 }
 
 #[test]

--- a/crates/landmass/src/query.rs
+++ b/crates/landmass/src/query.rs
@@ -3,8 +3,8 @@ use std::{collections::HashMap, marker::PhantomData};
 use thiserror::Error;
 
 use crate::{
-  nav_data::NodeRef, path::PathIndex, pathfinding, Archipelago,
-  CoordinateSystem, IslandId, NodeType,
+  Archipelago, CoordinateSystem, IslandId, NodeType, nav_data::NodeRef,
+  path::PathIndex, pathfinding,
 };
 
 /// A point on the navigation meshes.
@@ -55,7 +55,9 @@ impl<CS: CoordinateSystem> SampledPoint<'_, CS> {
 pub enum SamplePointError {
   #[error("The sample point is too far from any island.")]
   OutOfRange,
-  #[error("The navigation data of the archipelago has been mutated since the last update.")]
+  #[error(
+    "The navigation data of the archipelago has been mutated since the last update."
+  )]
   NavDataDirty,
 }
 
@@ -110,7 +112,10 @@ pub(crate) fn find_path<'a, CS: CoordinateSystem>(
   // handle it at all. I'd rather the "wins" we get from avoiding
   // double-sampling (in cases where the user samples a point to check for
   // validity and then finds a path).
-  assert!(!archipelago.nav_data.dirty, "The navigation data has been mutated, but we have SampledPoints, so this should be impossible.");
+  assert!(
+    !archipelago.nav_data.dirty,
+    "The navigation data has been mutated, but we have SampledPoints, so this should be impossible."
+  );
 
   for (node_type, cost) in override_node_type_costs.iter() {
     if *cost <= 0.0 {

--- a/crates/landmass/src/query.rs
+++ b/crates/landmass/src/query.rs
@@ -121,7 +121,9 @@ pub(crate) fn find_path<'a, CS: CoordinateSystem>(
   let Some(path) = pathfinding::find_path(
     &archipelago.nav_data,
     start_point.node_ref,
+    CS::to_landmass(&start_point.point),
     end_point.node_ref,
+    CS::to_landmass(&end_point.point),
     override_node_type_costs,
   )
   .path

--- a/crates/landmass/src/query_test.rs
+++ b/crates/landmass/src/query_test.rs
@@ -3,8 +3,8 @@ use std::{collections::HashMap, sync::Arc};
 use glam::Vec2;
 
 use crate::{
-  coords::XY, AgentOptions, Archipelago, FindPathError, FromAgentRadius,
-  Island, NavigationMesh, SamplePointError, Transform,
+  AgentOptions, Archipelago, FindPathError, FromAgentRadius, Island,
+  NavigationMesh, SamplePointError, Transform, coords::XY,
 };
 
 use super::{find_path, sample_point};

--- a/crates/landmass/src/util_test.rs
+++ b/crates/landmass/src/util_test.rs
@@ -2,7 +2,7 @@ use std::f32::consts::PI;
 
 use glam::Vec3;
 
-use crate::{util::BoundingBox, Transform, XYZ};
+use crate::{Transform, XYZ, util::BoundingBox};
 
 use super::BoundingBoxHierarchy;
 


### PR DESCRIPTION
Previously, we would pathfind using the polygons as nodes and the edges as actions to go between nodes. This was fairly simple and straightforward.

However, this resulted in 2 problems:
1) The start and end points were not taken into consideration. This means that if an agent is near an edge of a polygon, they would path as if they were at the center of the polygon, and similarly they would path towards the center of the end polygon. This meant that an agent could take a longer detour, since it is closer from the center of the node.
2) When an agent pathed through a node, the cost of the path would be calculated as always going to the center of the node first. This means even if the agent wanted to path between two adjacent edges, they would pretend to take a detour to the center of the node. For large nodes, this could end up being most of the cost of traveling through this node.

Instead of pathing assuming we are going to the node center, we can instead treat the edges between polygons as the nodes (so the agent starts at the edge) and then always uses the polygon its in as the path edge. This means that now we never take a detour to the center of the polygon, we always hop directly from edge to edge. One caveat with this is we still hop from edge center to edge center. This can lead to its own set of detours, but for now it should improve things.

In addition to using the edges as nodes, we also have two extra nodes: the start point and end point. These are literally the points you want to go to, so we can more accurately estimate the best path.