### PR TITLE
Replace `ord_subset::OrdVar` with our own implementation.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        toolchain: [stable, beta]
+        toolchain: [stable, beta, nightly]
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable

--- a/crates/landmass/Cargo.toml
+++ b/crates/landmass/Cargo.toml
@@ -17,7 +17,6 @@ keywords = ["navigation", "system", "pathfinding", "avoidance"]
 dodgy_2d = "0.5.4"
 glam = "0.29.1"
 kdtree = "0.7.0"
-ord_subset = "3.1.1"
 geo = "0.30.0"
 disjoint = "0.8.0"
 slotmap = "1.0.7"

--- a/crates/landmass/src/pathfinding.rs
+++ b/crates/landmass/src/pathfinding.rs
@@ -4,7 +4,6 @@ use std::{
 };
 
 use glam::Vec3;
-use ord_subset::OrdVar;
 
 use crate::{
   CoordinateSystem, Island, NavigationData, NodeType,
@@ -12,6 +11,7 @@ use crate::{
   nav_data::{BoundaryLinkId, NodeRef},
   nav_mesh::MeshEdgeRef,
   path::{BoundaryLinkSegment, IslandSegment, Path},
+  util::FloatOrd,
 };
 
 /// A concrete A* problem specifically for [`crate::Archipelago`]s.
@@ -291,8 +291,8 @@ pub(crate) fn find_path<CS: CoordinateSystem>(
         )
       })
       .filter(|pair| pair.1.is_finite())
-      .map(|pair| OrdVar::new_unchecked(pair.1))
-      .chain(std::iter::once(OrdVar::new_unchecked(1.0)))
+      .map(|pair| FloatOrd(pair.1))
+      .chain(std::iter::once(FloatOrd(1.0)))
       .min()
       .unwrap(),
     override_node_type_to_cost,


### PR DESCRIPTION
`ord_subset` has some bug on nightly. Rather than fix it or replacing it with another dep, I decided to just implement my own version of ordered floats. It's annoying I have to do this (I wish Rust exposed ordered floats directly), but there's no reason to add more dependencies for ~50 lines of code.

Fixes #126.