### PR TITLE
Add support for "height meshes".

### DIFF
--- a/crates/bevy_landmass/src/debug.rs
+++ b/crates/bevy_landmass/src/debug.rs
@@ -49,6 +49,8 @@ pub enum LineType {
   BoundaryEdge,
   /// An edge of a node that is connected to another node.
   ConnectivityEdge,
+  /// An edge of a triangle in the detail mesh.
+  HeightEdge,
   /// A link between two islands along their boundary edge.
   BoundaryLink,
   /// Part of an agent's current path. The corridor follows the path along
@@ -127,6 +129,7 @@ pub fn draw_archipelago_debug<CS: CoordinateSystem>(
         landmass::debug::LineType::ConnectivityEdge => {
           LineType::ConnectivityEdge
         }
+        landmass::debug::LineType::HeightEdge => LineType::HeightEdge,
         landmass::debug::LineType::BoundaryLink => LineType::BoundaryLink,
         landmass::debug::LineType::AgentCorridor(agent_id) => {
           LineType::AgentCorridor(
@@ -328,6 +331,7 @@ impl<CS: CoordinateSystem> DebugDrawer<CS> for GizmoDrawer<'_, '_, '_, CS> {
       match line_type {
         LineType::BoundaryEdge => Color::srgba(0.0, 0.0, 1.0, 0.6),
         LineType::ConnectivityEdge => Color::srgba(0.5, 0.5, 1.0, 0.6),
+        LineType::HeightEdge => Color::srgba_u8(33, 102, 57, 128),
         LineType::BoundaryLink => unreachable!(),
         LineType::AgentCorridor(_) => Color::srgba(0.6, 0.0, 0.6, 0.6),
         LineType::Target(_) => Color::srgba(1.0, 1.0, 0.0, 0.6),

--- a/crates/bevy_landmass/src/debug_test.rs
+++ b/crates/bevy_landmass/src/debug_test.rs
@@ -99,6 +99,7 @@ fn draws_archipelago_debug() {
       ],
       polygons: vec![vec![3, 2, 1, 0]],
       polygon_type_indices: vec![0],
+      height_mesh: None,
     }
     .validate()
     .expect("is valid"),

--- a/crates/bevy_landmass/src/lib.rs
+++ b/crates/bevy_landmass/src/lib.rs
@@ -22,9 +22,10 @@ mod island;
 mod landmass_structs;
 
 pub use landmass::{
-  AgentOptions, FindPathError, FromAgentRadius, NavigationMesh,
-  NewNodeTypeError, NodeType, PointSampleDistance3d, SamplePointError,
-  SetNodeTypeCostError, ValidNavigationMesh, ValidationError,
+  AgentOptions, FindPathError, FromAgentRadius, HeightNavigationMesh,
+  HeightPolygon, NavigationMesh, NewNodeTypeError, NodeType,
+  PointSampleDistance3d, SamplePointError, SetNodeTypeCostError,
+  ValidNavigationMesh, ValidationError,
 };
 
 pub use agent::*;

--- a/crates/bevy_landmass/src/lib_test.rs
+++ b/crates/bevy_landmass/src/lib_test.rs
@@ -49,6 +49,7 @@ fn computes_path_for_agent_and_updates_desired_velocity() {
       ],
       polygons: vec![vec![5, 4, 1, 0], vec![4, 3, 2, 1]],
       polygon_type_indices: vec![0, 0],
+      height_mesh: None,
     }
     .validate()
     .expect("is valid"),
@@ -380,6 +381,7 @@ fn adds_and_removes_islands() {
           vertices: vec![],
           polygons: vec![],
           polygon_type_indices: vec![],
+          height_mesh: None,
         }
         .validate()
         .unwrap(),
@@ -716,6 +718,7 @@ fn node_type_costs_are_used() {
         vec![3, 2, 13, 15],
       ],
       polygon_type_indices: vec![0, 0, 0, 0, 0, 0, 0, 1],
+      height_mesh: None,
     }
     .validate()
     .expect("nav mesh is valid"),
@@ -838,6 +841,7 @@ fn overridden_node_type_costs_are_used() {
         vec![3, 2, 13, 15],
       ],
       polygon_type_indices: vec![0, 0, 0, 0, 0, 0, 0, 1],
+      height_mesh: None,
     }
     .validate()
     .expect("nav mesh is valid"),
@@ -934,6 +938,7 @@ fn sample_point_error_on_out_of_range() {
       ],
       polygons: vec![vec![0, 1, 2, 3]],
       polygon_type_indices: vec![0],
+      height_mesh: None,
     }
     .validate()
     .expect("nav mesh is valid"),
@@ -992,6 +997,7 @@ fn samples_point_on_nav_mesh_or_near_nav_mesh() {
       ],
       polygons: vec![vec![0, 1, 2, 3]],
       polygon_type_indices: vec![0],
+      height_mesh: None,
     }
     .validate()
     .expect("nav mesh is valid"),
@@ -1082,6 +1088,7 @@ fn samples_node_types() {
       ],
       polygons: vec![vec![0, 1, 2, 3], vec![2, 1, 4, 5]],
       polygon_type_indices: vec![0, 1],
+      height_mesh: None,
     }
     .validate()
     .expect("nav mesh is valid"),
@@ -1159,6 +1166,7 @@ fn finds_path() {
       ],
       polygons: vec![vec![0, 1, 2, 3]],
       polygon_type_indices: vec![0],
+      height_mesh: None,
     }
     .validate()
     .expect("nav mesh is valid"),
@@ -1241,6 +1249,7 @@ fn island_matches_rotation_3d() {
       ],
       polygons: vec![vec![0, 1, 2, 3]],
       polygon_type_indices: vec![0],
+      height_mesh: None,
     }
     .validate()
     .expect("nav mesh is valid"),
@@ -1308,6 +1317,7 @@ fn island_matches_rotation_2d() {
       ],
       polygons: vec![vec![0, 1, 2, 3]],
       polygon_type_indices: vec![0],
+      height_mesh: None,
     }
     .validate()
     .expect("nav mesh is valid"),

--- a/crates/bevy_landmass/src/nav_mesh.rs
+++ b/crates/bevy_landmass/src/nav_mesh.rs
@@ -72,6 +72,7 @@ pub fn bevy_mesh_to_landmass_nav_mesh<CS: CoordinateSystem>(
     vertices,
     polygon_type_indices: (0..polygons.len()).map(|_| 0).collect(),
     polygons,
+    height_mesh: None,
   })
 }
 

--- a/crates/landmass/README.md
+++ b/crates/landmass/README.md
@@ -66,6 +66,7 @@ let nav_mesh = NavigationMesh {
   ],
   polygons: vec![vec![0, 1, 2, 3]],
   polygon_type_indices: vec![0],
+  height_mesh: None,
 };
 
 let valid_nav_mesh = Arc::new(

--- a/crates/landmass/src/agent_test.rs
+++ b/crates/landmass/src/agent_test.rs
@@ -88,6 +88,7 @@ fn has_reached_target_at_end_node() {
     vertices: vec![],
     polygons: vec![],
     polygon_type_indices: vec![],
+    height_mesh: None,
   }
   .validate()
   .expect("nav mesh is valid");
@@ -165,6 +166,7 @@ fn long_detour_reaches_target_in_different_ways() {
     ],
     polygons: vec![vec![0, 1, 2], vec![2, 1, 3, 4], vec![4, 3, 5]],
     polygon_type_indices: vec![0, 0, 0],
+    height_mesh: None,
   }
   .validate()
   .expect("nav mesh is valid");

--- a/crates/landmass/src/avoidance_test.rs
+++ b/crates/landmass/src/avoidance_test.rs
@@ -76,6 +76,7 @@ fn computes_obstacle_for_box() {
     ],
     polygons: vec![vec![0, 1, 2, 3]],
     polygon_type_indices: vec![0],
+    height_mesh: None,
   }
   .validate()
   .expect("Validation succeeds");
@@ -137,6 +138,7 @@ fn dead_end_makes_open_obstacle() {
       vec![9, 8, 10, 11],
     ],
     polygon_type_indices: vec![0, 0, 0, 0, 0],
+    height_mesh: None,
   }
   .validate()
   .expect("Validation succeeds");
@@ -280,6 +282,7 @@ fn split_borders() {
       vec![23, 22, 21, 24],
     ],
     polygon_type_indices: vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    height_mesh: None,
   }
   .validate()
   .expect("Validation succeeds");
@@ -338,6 +341,7 @@ fn creates_obstacles_across_boundary_link() {
       ],
       polygons: vec![vec![0, 1, 2, 3]],
       polygon_type_indices: vec![0],
+      height_mesh: None,
     }
     .validate()
     .expect("Validation succeeds"),
@@ -398,6 +402,7 @@ fn applies_no_avoidance_for_far_agents() {
     ],
     polygons: vec![vec![0, 1, 2, 3]],
     polygon_type_indices: vec![0],
+    height_mesh: None,
   }
   .validate()
   .expect("Validation succeeded.");
@@ -499,6 +504,7 @@ fn applies_avoidance_for_two_agents() {
     ],
     polygons: vec![vec![0, 1, 2, 3]],
     polygon_type_indices: vec![0],
+    height_mesh: None,
   }
   .validate()
   .expect("Validation succeeded.");
@@ -594,6 +600,7 @@ fn agent_avoids_character() {
     ],
     polygons: vec![vec![0, 1, 2, 3]],
     polygon_type_indices: vec![0],
+    height_mesh: None,
   }
   .validate()
   .expect("Validation succeeded.");
@@ -676,6 +683,7 @@ fn agent_speeds_up_to_avoid_character() {
     ],
     polygons: vec![vec![0, 1, 2, 3]],
     polygon_type_indices: vec![0],
+    height_mesh: None,
   }
   .validate()
   .expect("Validation succeeded.");
@@ -778,6 +786,7 @@ fn reached_target_agent_has_different_avoidance() {
       ],
       polygons: vec![vec![0, 1, 2, 3]],
       polygon_type_indices: vec![0],
+      height_mesh: None,
     }
     .validate()
     .unwrap(),
@@ -874,6 +883,7 @@ fn switching_nav_mesh_to_fewer_vertices_does_not_result_in_panic() {
     ],
     polygons: vec![vec![0, 1, 2, 3, 4, 5]],
     polygon_type_indices: vec![0],
+    height_mesh: None,
   }
   .validate()
   .unwrap();
@@ -888,6 +898,7 @@ fn switching_nav_mesh_to_fewer_vertices_does_not_result_in_panic() {
     ],
     polygons: vec![vec![0, 1, 2, 3]],
     polygon_type_indices: vec![0],
+    height_mesh: None,
   }
   .validate()
   .unwrap();

--- a/crates/landmass/src/debug_test.rs
+++ b/crates/landmass/src/debug_test.rs
@@ -91,6 +91,7 @@ fn draws_island_meshes_and_agents() {
       vec![10, 4, 14, 13],
     ],
     polygon_type_indices: vec![0, 0, 0, 0],
+    height_mesh: None,
   }
   .validate()
   .expect("Mesh is valid.");
@@ -426,6 +427,7 @@ fn draws_boundary_links() {
       ],
       polygons: vec![vec![0, 1, 2, 3]],
       polygon_type_indices: vec![0],
+      height_mesh: None,
     }
     .validate()
     .expect("The mesh is valid."),
@@ -474,6 +476,7 @@ fn fails_to_draw_dirty_archipelago() {
       ],
       polygons: vec![vec![0, 1, 2, 3]],
       polygon_type_indices: vec![0],
+      height_mesh: None,
     }
     .validate()
     .expect("The mesh is valid."),

--- a/crates/landmass/src/lib.rs
+++ b/crates/landmass/src/lib.rs
@@ -36,7 +36,10 @@ pub use island::{Island, IslandId};
 pub use nav_data::{
   IslandMut, NewNodeTypeError, NodeType, SetNodeTypeCostError,
 };
-pub use nav_mesh::{NavigationMesh, ValidNavigationMesh, ValidationError};
+pub use nav_mesh::{
+  HeightNavigationMesh, HeightPolygon, NavigationMesh, ValidNavigationMesh,
+  ValidationError,
+};
 pub use query::{FindPathError, SamplePointError, SampledPoint};
 pub use util::Transform;
 

--- a/crates/landmass/src/lib_test.rs
+++ b/crates/landmass/src/lib_test.rs
@@ -176,6 +176,7 @@ fn computes_and_follows_path() {
       vec![5, 6, 7, 8],
     ],
     polygon_type_indices: vec![0, 0, 0, 0, 0],
+    height_mesh: None,
   }
   .validate()
   .expect("is valid");
@@ -429,6 +430,7 @@ fn agent_speeds_up_to_avoid_character() {
       ],
       polygons: vec![vec![0, 1, 2, 3]],
       polygon_type_indices: vec![0],
+      height_mesh: None,
     }
     .validate()
     .expect("Validation succeeded."),
@@ -486,6 +488,7 @@ fn add_and_remove_islands() {
       vertices: vec![],
       polygons: vec![],
       polygon_type_indices: vec![],
+      height_mesh: None,
     }
     .validate()
     .unwrap(),
@@ -537,6 +540,7 @@ fn changed_island_is_not_dirty_after_update() {
         vertices: vec![],
         polygons: vec![],
         polygon_type_indices: vec![],
+        height_mesh: None,
       }
       .validate()
       .unwrap(),
@@ -577,6 +581,7 @@ fn samples_point() {
       ],
       polygons: vec![vec![0, 1, 2, 3]],
       polygon_type_indices: vec![0],
+      height_mesh: None,
     }
     .validate()
     .expect("nav mesh is valid"),
@@ -634,6 +639,7 @@ fn finds_path() {
       ],
       polygons: vec![vec![0, 1, 2, 3]],
       polygon_type_indices: vec![0],
+      height_mesh: None,
     }
     .validate()
     .expect("nav mesh is valid"),
@@ -718,6 +724,7 @@ fn agent_overrides_node_costs() {
         vec![3, 2, 13, 15],
       ],
       polygon_type_indices: vec![0, 0, 0, 0, 0, 0, 0, 1],
+      height_mesh: None,
     }
     .validate()
     .expect("nav mesh is valid"),

--- a/crates/landmass/src/nav_data_test.rs
+++ b/crates/landmass/src/nav_data_test.rs
@@ -37,6 +37,7 @@ fn samples_points() {
     ],
     polygons: vec![vec![0, 1, 6, 7], vec![1, 2, 5, 6], vec![2, 3, 4, 5]],
     polygon_type_indices: vec![0, 0, 0],
+    height_mesh: None,
   }
   .validate()
   .expect("is valid");
@@ -192,6 +193,7 @@ fn link_edges_between_islands_links_touching_islands() {
         vec![6, 0, 5, 11],
       ],
       polygon_type_indices: vec![0, 1, 1, 1, 0, 0],
+      height_mesh: None,
     }
     .validate()
     .expect("is valid."),
@@ -221,6 +223,7 @@ fn link_edges_between_islands_links_touching_islands() {
         vec![10, 11, 2, 1],
       ],
       polygon_type_indices: vec![0, 0, 0, 0, 1],
+      height_mesh: None,
     }
     .validate()
     .expect("is valid."),
@@ -513,6 +516,7 @@ fn update_links_islands_and_unlinks_on_delete() {
       ],
       polygons: vec![vec![0, 1, 2, 5], vec![4, 5, 2, 3]],
       polygon_type_indices: vec![0, 0],
+      height_mesh: None,
     }
     .validate()
     .expect("is valid."),
@@ -808,6 +812,7 @@ fn modifies_node_boundaries_for_linked_islands() {
       ],
       polygons: vec![vec![0, 1, 2, 3], vec![3, 2, 4, 5]],
       polygon_type_indices: vec![0, 0],
+      height_mesh: None,
     }
     .validate()
     .expect("is valid."),
@@ -879,6 +884,7 @@ fn stale_modified_nodes_are_removed() {
       ],
       polygons: vec![vec![0, 1, 2, 3], vec![3, 2, 4, 5]],
       polygon_type_indices: vec![0, 0],
+      height_mesh: None,
     }
     .validate()
     .expect("is valid."),
@@ -920,6 +926,7 @@ fn empty_navigation_mesh_is_safe() {
       ],
       polygons: vec![vec![0, 1, 2, 3]],
       polygon_type_indices: vec![0],
+      height_mesh: None,
     }
     .validate()
     .expect("A square nav mesh is valid."),
@@ -930,6 +937,7 @@ fn empty_navigation_mesh_is_safe() {
       vertices: vec![],
       polygons: vec![],
       polygon_type_indices: vec![],
+      height_mesh: None,
     }
     .validate()
     .expect("An empty nav mesh is valid."),
@@ -1000,6 +1008,7 @@ fn cannot_remove_used_node_type() {
       ],
       polygons: vec![vec![0, 1, 2, 3]],
       polygon_type_indices: vec![0],
+      height_mesh: None,
     }
     .validate()
     .expect("mesh is valid"),
@@ -1075,6 +1084,7 @@ fn panics_on_invalid_node_type() {
       ],
       polygons: vec![vec![0, 1, 2, 3]],
       polygon_type_indices: vec![0],
+      height_mesh: None,
     }
     .validate()
     .expect("mesh is valid"),

--- a/crates/landmass/src/nav_mesh_test.rs
+++ b/crates/landmass/src/nav_mesh_test.rs
@@ -24,6 +24,7 @@ fn validation_computes_bounds() {
     ],
     polygons: vec![vec![0, 1, 2], vec![3, 4, 5]],
     polygon_type_indices: vec![0, 0],
+    height_mesh: None,
   };
 
   let valid_mesh =
@@ -44,6 +45,7 @@ fn correctly_computes_bounds_for_small_number_of_points() {
     ],
     polygons: vec![vec![0, 1, 2]],
     polygon_type_indices: vec![0],
+    height_mesh: None,
   }
   .validate()
   .expect("Validation succeeds");
@@ -67,6 +69,7 @@ fn polygons_derived_and_vertices_copied() {
     ],
     polygons: vec![vec![0, 1, 2], vec![3, 4, 5]],
     polygon_type_indices: vec![1337, 123],
+    height_mesh: None,
   };
 
   let expected_polygons = vec![
@@ -111,6 +114,7 @@ fn error_on_wrong_type_indices_length() {
     ],
     polygons: vec![vec![0, 1, 2]],
     polygon_type_indices: vec![0, 0],
+    height_mesh: None,
   };
 
   let error = source_mesh
@@ -139,6 +143,7 @@ fn error_on_concave_polygon() {
     ],
     polygons: vec![vec![0, 1, 2]],
     polygon_type_indices: vec![0],
+    height_mesh: None,
   };
 
   let error = source_mesh
@@ -160,6 +165,7 @@ fn error_on_small_polygon() {
     vertices: vec![Vec3::new(0.0, 0.0, 0.0), Vec3::new(1.0, 1.0, 0.0)],
     polygons: vec![vec![0, 1]],
     polygon_type_indices: vec![0],
+    height_mesh: None,
   };
 
   let error = source_mesh
@@ -187,6 +193,7 @@ fn error_on_bad_polygon_index() {
     ],
     polygons: vec![vec![0, 1, 3]],
     polygon_type_indices: vec![0],
+    height_mesh: None,
   };
 
   let error = source_mesh
@@ -214,6 +221,7 @@ fn error_on_degenerate_edge() {
     ],
     polygons: vec![vec![0, 1, 1, 2]],
     polygon_type_indices: vec![0],
+    height_mesh: None,
   };
 
   let error = source_mesh
@@ -245,6 +253,7 @@ fn error_on_doubly_connected_edge() {
     ],
     polygons: vec![vec![0, 1, 2], vec![1, 3, 4, 2], vec![1, 5, 6, 2]],
     polygon_type_indices: vec![0, 0, 0],
+    height_mesh: None,
   };
 
   let error = source_mesh
@@ -283,6 +292,7 @@ fn derives_connectivity_and_boundary_edges() {
       vec![2, 4, 8, 7],
     ],
     polygon_type_indices: vec![0, 0, 0, 0],
+    height_mesh: None,
   };
 
   let mut valid_mesh =
@@ -366,6 +376,7 @@ fn finds_regions() {
       vec![11, 10, 12, 13],
     ],
     polygon_type_indices: vec![0, 0, 0, 0, 0],
+    height_mesh: None,
   }
   .validate()
   .expect("Mesh is valid.");
@@ -403,6 +414,7 @@ fn sample_point_returns_none_for_far_point() {
       vec![10, 4, 14, 13],
     ],
     polygon_type_indices: vec![0, 0, 0, 0],
+    height_mesh: None,
   }
   .validate()
   .expect("Mesh is valid.");
@@ -487,6 +499,7 @@ fn sample_point_in_nodes() {
       vec![10, 4, 14, 13],
     ],
     polygon_type_indices: vec![0, 0, 0, 0],
+    height_mesh: None,
   }
   .validate()
   .expect("Mesh is valid.");
@@ -589,6 +602,7 @@ fn sample_point_near_node() {
       vec![10, 4, 14, 13],
     ],
     polygon_type_indices: vec![0, 0, 0, 0],
+    height_mesh: None,
   }
   .validate()
   .expect("Mesh is valid.");
@@ -681,6 +695,7 @@ fn sample_ignores_closer_horizontal() {
     ],
     polygons: vec![vec![0, 1, 2, 3], vec![4, 5, 6, 7]],
     polygon_type_indices: vec![0; 2],
+    height_mesh: None,
   }
   .validate()
   .expect("mesh is valid");
@@ -717,6 +732,7 @@ fn sample_favoring_vertical() {
     ],
     polygons: vec![vec![0, 1, 2, 3], vec![4, 5, 6, 7]],
     polygon_type_indices: vec![0; 2],
+    height_mesh: None,
   }
   .validate()
   .expect("mesh is valid");
@@ -748,6 +764,7 @@ fn sample_filters_vertical_points_differently() {
     ],
     polygons: vec![vec![0, 1, 2, 3]],
     polygon_type_indices: vec![0; 1],
+    height_mesh: None,
   }
   .validate()
   .expect("mesh is valid.");

--- a/crates/landmass/src/path_test.rs
+++ b/crates/landmass/src/path_test.rs
@@ -67,6 +67,7 @@ fn finds_next_point_for_organic_map() {
       vec![10, 4, 14, 13],
     ],
     polygon_type_indices: vec![0, 0, 0, 0],
+    height_mesh: None,
   }
   .validate()
   .expect("Mesh is valid.");
@@ -174,6 +175,7 @@ fn finds_next_point_in_zig_zag() {
       vec![25, 23, 26, 27],
     ],
     polygon_type_indices: vec![0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    height_mesh: None,
   }
   .validate()
   .expect("Mesh is valid.");
@@ -251,6 +253,7 @@ fn starts_at_end_index_goes_to_end_point() {
     ],
     polygons: vec![vec![0, 1, 2, 3], vec![3, 2, 4, 5]],
     polygon_type_indices: vec![0, 0],
+    height_mesh: None,
   }
   .validate()
   .expect("Mesh is valid.");

--- a/crates/landmass/src/pathfinding_test.rs
+++ b/crates/landmass/src/pathfinding_test.rs
@@ -65,6 +65,7 @@ fn finds_path_in_archipelago() {
       vec![10, 4, 14, 13],
     ],
     polygon_type_indices: vec![0, 0, 0, 0],
+    height_mesh: None,
   }
   .validate()
   .expect("Mesh is valid.");
@@ -164,6 +165,7 @@ fn finds_paths_on_two_islands() {
       vec![10, 4, 14, 13],
     ],
     polygon_type_indices: vec![0, 0, 0, 0],
+    height_mesh: None,
   }
   .validate()
   .expect("Mesh is valid.");
@@ -251,6 +253,7 @@ fn no_path_between_disconnected_islands() {
       vec![10, 4, 14, 13],
     ],
     polygon_type_indices: vec![0, 0, 0, 0],
+    height_mesh: None,
   }
   .validate()
   .expect("Mesh is valid.");
@@ -307,6 +310,7 @@ fn find_path_across_connected_islands() {
       ],
       polygons: vec![vec![0, 1, 2, 3]],
       polygon_type_indices: vec![0],
+      height_mesh: None,
     }
     .validate()
     .expect("Mesh is valid."),
@@ -418,6 +422,7 @@ fn finds_path_across_different_islands() {
       ],
       polygons: vec![vec![0, 1, 2, 3]],
       polygon_type_indices: vec![0],
+      height_mesh: None,
     }
     .validate()
     .expect("Mesh is valid."),
@@ -434,6 +439,7 @@ fn finds_path_across_different_islands() {
       ],
       polygons: vec![vec![0, 1, 2, 3], vec![2, 1, 4, 5]],
       polygon_type_indices: vec![0, 0],
+      height_mesh: None,
     }
     .validate()
     .expect("Mesh is valid."),
@@ -509,6 +515,7 @@ fn aborts_early_for_unconnected_regions() {
       ],
       polygons: vec![vec![0, 1, 2, 3]],
       polygon_type_indices: vec![0],
+      height_mesh: None,
     }
     .validate()
     .expect("Mesh is valid."),
@@ -611,6 +618,7 @@ fn detour_for_high_cost_path() {
         vec![3, 2, 12, 14],
       ],
       polygon_type_indices: vec![0, 0, 0, 0, 0, 0, 0, 1],
+      height_mesh: None,
     }
     .validate()
     .expect("nav mesh is valid"),
@@ -665,6 +673,7 @@ fn detour_for_high_cost_path_across_boundary_links() {
       ],
       polygons: vec![vec![0, 1, 2, 3], vec![2, 1, 4, 5], vec![5, 4, 6, 7]],
       polygon_type_indices: vec![0, 0, 0],
+      height_mesh: None,
     }
     .validate()
     .expect("nav mesh is valid"),
@@ -698,6 +707,7 @@ fn detour_for_high_cost_path_across_boundary_links() {
         vec![6, 4, 10, 11],
       ],
       polygon_type_indices: vec![0, 0, 0, 1, 0],
+      height_mesh: None,
     }
     .validate()
     .expect("nav mesh is valid"),
@@ -799,6 +809,7 @@ fn fast_path_not_ignored_by_heuristic() {
         vec![3, 2, 12, 14],
       ],
       polygon_type_indices: vec![1, 0, 0, 0, 0, 1, 1, 1],
+      height_mesh: None,
     }
     .validate()
     .expect("nav mesh is valid"),
@@ -853,6 +864,7 @@ fn infinite_or_nan_cost_cannot_find_path_between_nodes() {
       ],
       polygons: vec![vec![0, 1, 2, 3], vec![2, 1, 4, 5], vec![5, 4, 6, 7]],
       polygon_type_indices: vec![0, 1, 0],
+      height_mesh: None,
     }
     .validate()
     .expect("mesh is valid"),
@@ -935,6 +947,7 @@ fn detour_for_overridden_high_cost_path() {
         vec![3, 2, 12, 14],
       ],
       polygon_type_indices: vec![0, 0, 0, 0, 0, 0, 0, 1],
+      height_mesh: None,
     }
     .validate()
     .expect("nav mesh is valid"),
@@ -1023,6 +1036,7 @@ fn big_node_does_not_skew_pathing() {
         vec![4, 5, 9, 8, 17, 16],
       ],
       polygon_type_indices: vec![0, 0, 0, 0, 0, 0, 0, 0],
+      height_mesh: None,
     }
     .validate()
     .expect("nav mesh is valid"),
@@ -1110,6 +1124,7 @@ fn start_and_end_point_influences_path() {
         vec![7, 8, 13, 12],
       ],
       polygon_type_indices: vec![0, 0, 0, 0, 0, 0],
+      height_mesh: None,
     }
     .validate()
     .expect("nav mesh is valid"),

--- a/crates/landmass/src/query_test.rs
+++ b/crates/landmass/src/query_test.rs
@@ -24,6 +24,7 @@ fn error_on_dirty_nav_mesh() {
       ],
       polygons: vec![vec![0, 1, 2, 3]],
       polygon_type_indices: vec![0],
+      height_mesh: None,
     }
     .validate()
     .expect("nav mesh is valid"),
@@ -60,6 +61,7 @@ fn error_on_out_of_range() {
       ],
       polygons: vec![vec![0, 1, 2, 3]],
       polygon_type_indices: vec![0],
+      height_mesh: None,
     }
     .validate()
     .expect("nav mesh is valid"),
@@ -98,6 +100,7 @@ fn samples_point_on_nav_mesh_or_near_nav_mesh() {
       ],
       polygons: vec![vec![0, 1, 2, 3]],
       polygon_type_indices: vec![0],
+      height_mesh: None,
     }
     .validate()
     .expect("nav mesh is valid"),
@@ -170,6 +173,7 @@ fn samples_node_types() {
         vec![7, 6, 8, 9],
       ],
       polygon_type_indices: vec![0, 1, 2, 3],
+      height_mesh: None,
     }
     .validate()
     .expect("nav mesh is valid"),
@@ -236,6 +240,7 @@ fn no_path() {
       ],
       polygons: vec![vec![0, 1, 2, 3]],
       polygon_type_indices: vec![0],
+      height_mesh: None,
     }
     .validate()
     .expect("nav mesh is valid"),
@@ -281,6 +286,7 @@ fn finds_path() {
       ],
       polygons: vec![vec![0, 1, 2, 3]],
       polygon_type_indices: vec![0],
+      height_mesh: None,
     }
     .validate()
     .expect("nav mesh is valid"),
@@ -365,6 +371,7 @@ fn finds_path_with_override_node_types() {
         vec![3, 2, 13, 15],
       ],
       polygon_type_indices: vec![0, 0, 0, 0, 0, 0, 0, 1],
+      height_mesh: None,
     }
     .validate()
     .expect("nav mesh is valid"),
@@ -427,6 +434,7 @@ fn find_path_returns_error_on_invalid_node_cost() {
       ],
       polygons: vec![vec![0, 1, 2, 3]],
       polygon_type_indices: vec![0],
+      height_mesh: None,
     }
     .validate()
     .expect("nav mesh is valid"),
@@ -484,6 +492,7 @@ fn start_and_end_in_same_node() {
       ],
       polygons: vec![vec![0, 1, 2, 3]],
       polygon_type_indices: vec![0],
+      height_mesh: None,
     }
     .validate()
     .expect("nav mesh is valid"),


### PR DESCRIPTION
In previous versions, we only supported sampling on the nav mesh. This meant that if your nav mesh had too low a resolution, your agent would not be considered on the nav mesh (even though they are on the geometry). The height mesh allows for a higher resolution that we only use for sampling and then after that we path on the regular nav mesh, so we get the performance of the nav mesh for search, but the accuracy for sampling with the height mesh.