### PR TITLE
Allow coordinate systems to specify how they should be flipped to be CCW.

### DIFF
--- a/crates/bevy_landmass/src/coords.rs
+++ b/crates/bevy_landmass/src/coords.rs
@@ -35,6 +35,8 @@ impl LandmassCoordinateSystem for ThreeD {
   type Coordinate = bevy_math::Vec3;
   type SampleDistance = PointSampleDistance3d;
 
+  const FLIP_POLYGONS: bool = true;
+
   fn to_landmass(v: &Self::Coordinate) -> landmass::Vec3 {
     landmass::Vec3::new(v.x, -v.z, v.y)
   }
@@ -69,6 +71,8 @@ pub struct TwoD;
 impl LandmassCoordinateSystem for TwoD {
   type Coordinate = bevy_math::Vec2;
   type SampleDistance = f32;
+
+  const FLIP_POLYGONS: bool = false;
 
   fn to_landmass(v: &Self::Coordinate) -> landmass::Vec3 {
     landmass::Vec3::new(v.x, v.y, 0.0)

--- a/crates/bevy_landmass/src/debug_test.rs
+++ b/crates/bevy_landmass/src/debug_test.rs
@@ -97,7 +97,7 @@ fn draws_archipelago_debug() {
         Vec3::new(4.0, 0.0, 4.0),
         Vec3::new(1.0, 0.0, 4.0),
       ],
-      polygons: vec![vec![3, 2, 1, 0]],
+      polygons: vec![vec![0, 1, 2, 3]],
       polygon_type_indices: vec![0],
       height_mesh: None,
     }
@@ -261,7 +261,7 @@ fn draws_avoidance_data_when_requested() {
         Vec3::new(11.0, 1.0, 11.0),
         Vec3::new(1.0, 1.0, 11.0),
       ],
-      polygons: vec![vec![3, 2, 1, 0]],
+      polygons: vec![vec![0, 1, 2, 3]],
       polygon_type_indices: vec![0],
       height_mesh: None,
     }

--- a/crates/bevy_landmass/src/lib_test.rs
+++ b/crates/bevy_landmass/src/lib_test.rs
@@ -47,7 +47,7 @@ fn computes_path_for_agent_and_updates_desired_velocity() {
         Vec3::new(3.0, 0.0, 2.0),
         Vec3::new(1.0, 0.0, 2.0),
       ],
-      polygons: vec![vec![5, 4, 1, 0], vec![4, 3, 2, 1]],
+      polygons: vec![vec![0, 1, 4, 5], vec![1, 2, 3, 4]],
       polygon_type_indices: vec![0, 0],
       height_mesh: None,
     }
@@ -1244,8 +1244,8 @@ fn island_matches_rotation_3d() {
       vertices: vec![
         Vec3::new(0.0, 0.0, 0.0),
         Vec3::new(1.0, 0.0, 0.0),
-        Vec3::new(1.0, 0.0, -1.0),
-        Vec3::new(0.0, 0.0, -1.0),
+        Vec3::new(1.0, 0.0, 1.0),
+        Vec3::new(0.0, 0.0, 1.0),
       ],
       polygons: vec![vec![0, 1, 2, 3]],
       polygon_type_indices: vec![0],

--- a/crates/landmass/src/coords.rs
+++ b/crates/landmass/src/coords.rs
@@ -9,6 +9,13 @@ pub trait CoordinateSystem {
   /// The type to use for point sampling options.
   type SampleDistance: PointSampleDistance;
 
+  /// Whether to flip polygons after conversion.
+  ///
+  /// Landmass coordinates expect polygons are in CCW order. However, your
+  /// coordinate system could flip one of the axes, such that CCW polygons in
+  /// your coordinate system become CW polygons in landmass coordinates.
+  const FLIP_POLYGONS: bool;
+
   /// Converts a coordinate in this system to the standard coordinate system.
   fn to_landmass(v: &Self::Coordinate) -> Vec3;
 
@@ -64,6 +71,8 @@ pub struct XYZ;
 impl CoordinateSystem for XYZ {
   type Coordinate = Vec3;
   type SampleDistance = PointSampleDistance3d;
+
+  const FLIP_POLYGONS: bool = false;
 
   fn to_landmass(v: &Self::Coordinate) -> Vec3 {
     *v
@@ -132,6 +141,8 @@ pub struct XY;
 impl CoordinateSystem for XY {
   type Coordinate = Vec2;
   type SampleDistance = f32;
+
+  const FLIP_POLYGONS: bool = false;
 
   fn to_landmass(v: &Self::Coordinate) -> Vec3 {
     Vec3::new(v.x, v.y, 0.0)


### PR DESCRIPTION
Previously, if your coordinate system did something "weird" while converting coordinates, CCW polygons would become CW, meaning you would need to create your nav meshes CW in order for them to be flipped during the conversion into CCW polygons.

Now, coordinate systems can say they are flipped to automatically flip the polygons so your nav meshes can be CCW and stay CCW in landmass.