### PR TITLE
Make debug rendering of paths actually match how they are computed.

### DIFF
--- a/crates/landmass/src/agent_test.rs
+++ b/crates/landmass/src/agent_test.rs
@@ -116,6 +116,8 @@ fn has_reached_target_at_end_node() {
       portal_edge_index: vec![],
     }],
     boundary_link_segments: vec![],
+    start_point: Vec3::ZERO,
+    end_point: Vec3::ZERO,
   };
 
   let first_path_index = PathIndex::from_corridor_index(0, 0);
@@ -196,6 +198,8 @@ fn long_detour_reaches_target_in_different_ways() {
       portal_edge_index: vec![1, 2],
     }],
     boundary_link_segments: vec![],
+    start_point: Vec3::ZERO,
+    end_point: Vec3::ZERO,
   };
 
   {
@@ -375,8 +379,12 @@ fn nothing_or_clear_path_for_no_target() {
     RepathResult::DoNothing
   );
 
-  agent.current_path =
-    Some(Path { island_segments: vec![], boundary_link_segments: vec![] });
+  agent.current_path = Some(Path {
+    island_segments: vec![],
+    boundary_link_segments: vec![],
+    start_point: Vec3::ZERO,
+    end_point: Vec3::ZERO,
+  });
 
   assert_eq!(
     does_agent_need_repath(
@@ -463,6 +471,8 @@ fn repaths_for_invalid_path_or_nodes_off_path() {
       portal_edge_index: vec![],
     }],
     boundary_link_segments: vec![],
+    start_point: Vec3::ZERO,
+    end_point: Vec3::ZERO,
   });
 
   // Invalidated island.

--- a/crates/landmass/src/path.rs
+++ b/crates/landmass/src/path.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 /// A path computed on the navigation data.
-#[derive(PartialEq, Eq, Clone, Debug)]
+#[derive(PartialEq, Clone, Debug)]
 pub struct Path {
   /// The segments of this path on islands. These are joined together with
   /// [`Path::boundary_link_segments`]. Note even if an island is only used to
@@ -17,6 +17,14 @@ pub struct Path {
   /// The boundary links that connect the island segments. Must have exactly
   /// one less element than [`Path::island_segments`].
   pub(crate) boundary_link_segments: Vec<BoundaryLinkSegment>,
+  /// The point where this path was started from.
+  ///
+  /// This is not used, but is good for debugging.
+  pub(crate) start_point: Vec3,
+  /// The point where this path was originally targetting.
+  ///
+  /// This is not used, but is good for debugging.
+  pub(crate) end_point: Vec3,
 }
 
 /// Part of a path entirely along a single island.

--- a/crates/landmass/src/path_test.rs
+++ b/crates/landmass/src/path_test.rs
@@ -89,6 +89,8 @@ fn finds_next_point_for_organic_map() {
       portal_edge_index: vec![4, 2],
     }],
     boundary_link_segments: vec![],
+    start_point: transform.apply(Vec3::new(3.0, 1.5, 0.0)),
+    end_point: transform.apply(Vec3::new(2.5, 4.5, 0.5)),
   };
 
   assert_eq!(
@@ -96,15 +98,9 @@ fn finds_next_point_for_organic_map() {
       &path,
       &archipelago.nav_data,
       /* start= */
-      (
-        PathIndex::from_corridor_index(0, 0),
-        transform.apply(Vec3::new(3.0, 1.5, 0.0))
-      ),
+      (PathIndex::from_corridor_index(0, 0), path.start_point),
       /* end= */
-      (
-        PathIndex::from_corridor_index(0, 2),
-        transform.apply(Vec3::new(2.5, 4.5, 0.5))
-      ),
+      (PathIndex::from_corridor_index(0, 2), path.end_point),
       /* iteration_limit= */ 3,
     ),
     [
@@ -197,6 +193,8 @@ fn finds_next_point_in_zig_zag() {
       portal_edge_index: vec![2, 2, 2, 2, 1, 2, 2, 2, 2, 2, 2, 2, 2, 1],
     }],
     boundary_link_segments: vec![],
+    start_point: transform.apply(Vec3::new(0.5, 0.5, 0.0)),
+    end_point: transform.apply(Vec3::new(-3.5, 14.0, 0.0)),
   };
 
   assert_eq!(
@@ -204,15 +202,9 @@ fn finds_next_point_in_zig_zag() {
       &path,
       &archipelago.nav_data,
       /* start= */
-      (
-        PathIndex::from_corridor_index(0, 0),
-        transform.apply(Vec3::new(0.5, 0.5, 0.0))
-      ),
+      (PathIndex::from_corridor_index(0, 0), path.start_point),
       /* end= */
-      (
-        PathIndex::from_corridor_index(0, 14),
-        transform.apply(Vec3::new(-3.5, 14.0, 0.0))
-      ),
+      (PathIndex::from_corridor_index(0, 14), path.end_point),
       /* iteration_limit= */ 5,
     ),
     [
@@ -273,6 +265,8 @@ fn starts_at_end_index_goes_to_end_point() {
       portal_edge_index: vec![2],
     }],
     boundary_link_segments: vec![],
+    start_point: Vec3::ZERO,
+    end_point: Vec3::ZERO,
   };
 
   assert_eq!(
@@ -326,6 +320,8 @@ fn path_not_valid_for_invalidated_islands_or_boundary_links() {
         boundary_link: boundary_link_id_2,
       },
     ],
+    start_point: Vec3::ZERO,
+    end_point: Vec3::ZERO,
   };
 
   assert!(path.is_valid(
@@ -400,6 +396,8 @@ fn indices_in_path_are_found() {
         boundary_link: boundary_link_id_2,
       },
     ],
+    start_point: Vec3::ZERO,
+    end_point: Vec3::ZERO,
   };
 
   assert_eq!(
@@ -476,6 +474,8 @@ fn indices_in_path_are_found_rev() {
         boundary_link: boundary_link_id_2,
       },
     ],
+    start_point: Vec3::ZERO,
+    end_point: Vec3::ZERO,
   };
 
   assert_eq!(

--- a/crates/landmass/src/pathfinding.rs
+++ b/crates/landmass/src/pathfinding.rs
@@ -303,8 +303,12 @@ pub(crate) fn find_path<CS: CoordinateSystem>(
     return PathResult { stats: path_result.stats, path: None };
   };
 
-  let mut output_path =
-    Path { island_segments: vec![], boundary_link_segments: vec![] };
+  let mut output_path = Path {
+    island_segments: vec![],
+    boundary_link_segments: vec![],
+    start_point,
+    end_point,
+  };
 
   output_path.island_segments.push(IslandSegment {
     island_id: start_node.island_id,


### PR DESCRIPTION
Since #124, we no longer navigate through the center of nodes. Instead we navigate through the center of edges.

Unfortunately the debug view hasn't kept up with that. In a sense it was still "correct" - it was rendering the corridor - not the path. However I think that vis poorly communicates the path the agent is trying to travel, and I think the more important thing to communicate is what the agent "was thinking" when they planned their path. So I'm now drawing the corridor through the center of edges.

Here's a before:

<img width="1866" height="1289" alt="image" src="https://github.com/user-attachments/assets/8f7bcff2-5457-4243-93f1-6fbedb835db5" />

And here's an after:

<img width="1883" height="1242" alt="image" src="https://github.com/user-attachments/assets/4ced94a3-12de-4ae4-aab3-61759384c86f" />
