### PR TITLE
Replace node types with just directly using the type index.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        toolchain: [stable, beta, nightly]
+        toolchain: [stable, beta]
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,16 @@
   - Note: counter-clockwise is defined as having a cross-product that points "up" (we love the
     right-hand rule!). If converting to `landmass` coordinates would result in a cross product
     pointing towards negative Z, you should enable flipping!
+- No more `type_index_to_node_type`!
+  - In previous versions, nav meshes stored a type index, but this type index needed to be
+    "translated" into an actual node type, which you could then assign a cost to. This was a lot of
+    steps! The more pressing concern was that it was difficult to apply that "translation" to the
+    node type when loading a nav mesh. Node types needed to be created on the archipelago itself,
+    and then when loading up a nav mesh, you would need to set the node type mappings on it (which
+    could be difficult from `bevy_landmass` for example).
+  - Now, node types are gone, and you can just set the cost of a type index! Note this means that
+    all your nav meshes must share the same meaning for each type index (e.g., 1 means road in every
+    nav mesh).
 - `bevy_landmass`: More configurable debug rendering.
   - While the `bevy_landmass` API allows you to create your own `DebugDrawer`, the default one is
     good enough for a **lot** of cases. To further expand its usefulness, we have replaced
@@ -58,6 +68,11 @@
 
 - `CoordinateSystem` now has a `const FLIP_POLYGONS: bool`. To maintain existing behaviour, set it
   to `false`.
+- `NodeType` has been removed. Replace it with the corresponding type indices. This could require
+  mutating any serialized nav meshes to ensure their type indices are "globally-unique" relative to
+  other nav meshes.
+- All node type functions (e.g., `add_node_type`, `get_node_type_cost`) have been replaced by
+  versions directly relevant to type indices.
 - `bevy_landmass`: The `ThreeD` coordinate system is now flipped! In previous versions, navigation
   meshes in 3D were expected to have clockwise-oriented polygons. Now, they are expected to be
   counter-clockwise oriented. This puts it in sync with every other coordinate system in `landmass`/
@@ -66,3 +81,4 @@
 - `bevy_landmass`: `LandmassGizmoConfigGroup` has been replaced by `LandmassGizmos`. If you were
   configuring the `LandmassGizmoConfigGroup`, replace it with `LandmassGizmos::default()` (since it
   is no longer a ZST).
+- `bevy_landmass`: `NavMesh` no longer contains a `type_index_to_node_type` field. Just remove it!

--- a/crates/bevy_landmass/README.md
+++ b/crates/bevy_landmass/README.md
@@ -9,12 +9,13 @@ A plugin for [Bevy](https://bevyengine.org) to allow using
 direction for characters using pathfinding.
 
 To use `bevy_landmass`:
-1) Add `LandmassPlugin` to your app.
-2) Spawn an entity with an `Archipelago` component.
-3) Spawn an entity with an `IslandBundle`, a `TransformBundle` (or any other
+
+1. Add `LandmassPlugin` to your app.
+2. Spawn an entity with an `Archipelago` component.
+3. Spawn an entity with an `IslandBundle`, a `TransformBundle` (or any other
    bundle which includes a `Transform` and `GlobalTransform`), and an
    `IslandNavMesh` component.
-4) Spawn entities with the `AgentBundle` and a `TransformBundle` (or any other
+4. Spawn entities with the `AgentBundle` and a `TransformBundle` (or any other
    bundle which includes a `Transform` and `GlobalTransform`).
 
 Note the `Archipelago` can be created later, even if the agents/islands already
@@ -59,7 +60,7 @@ fn set_up_scene(
         nav_mesh: NavMeshHandle(nav_mesh_handle.clone()),
       },
     ));
-  
+
   // The nav mesh can be populated in another system, or even several frames
   // later.
   let nav_mesh = Arc::new(NavigationMesh2d {
@@ -81,10 +82,7 @@ fn set_up_scene(
       polygon_type_indices: vec![0, 0, 0],
       height_mesh: None,
     }.validate().expect("is valid"));
-  nav_meshes.insert(&nav_mesh_handle, NavMesh2d{
-    nav_mesh,
-    type_index_to_node_type: Default::default(),
-  });
+  nav_meshes.insert(&nav_mesh_handle, NavMesh2d { nav_mesh });
 
   commands.spawn((
     Transform::from_translation(Vec3::new(1.5, 1.5, 0.0)),
@@ -120,8 +118,8 @@ fn quit(mut exit: EventWriter<AppExit>) {
 
 License under either of
 
-* Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
-* MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 
 at your option.
 

--- a/crates/bevy_landmass/src/agent.rs
+++ b/crates/bevy_landmass/src/agent.rs
@@ -307,7 +307,7 @@ pub(crate) fn sync_agent_input_state<CS: CoordinateSystem>(
     match node_type_cost_overrides {
       None => {
         for (node_type, _) in
-          landmass_agent.get_node_type_cost_overrides().collect::<Vec<_>>()
+          landmass_agent.get_type_index_cost_overrides().collect::<Vec<_>>()
         {
           landmass_agent.remove_overridden_node_type_cost(node_type);
         }
@@ -318,7 +318,7 @@ pub(crate) fn sync_agent_input_state<CS: CoordinateSystem>(
         }
 
         for (node_type, _) in
-          landmass_agent.get_node_type_cost_overrides().collect::<Vec<_>>()
+          landmass_agent.get_type_index_cost_overrides().collect::<Vec<_>>()
         {
           if node_type_cost_overrides.0.contains_key(&node_type) {
             continue;
@@ -327,7 +327,7 @@ pub(crate) fn sync_agent_input_state<CS: CoordinateSystem>(
         }
 
         for (&node_type, &cost) in node_type_cost_overrides.0.iter() {
-          assert!(landmass_agent.override_node_type_cost(node_type, cost));
+          assert!(landmass_agent.override_type_index_cost(node_type, cost));
         }
       }
     }

--- a/crates/bevy_landmass/src/debug_test.rs
+++ b/crates/bevy_landmass/src/debug_test.rs
@@ -108,7 +108,7 @@ fn draws_archipelago_debug() {
   let nav_mesh_handle = app
     .world_mut()
     .resource_mut::<Assets<NavMesh3d>>()
-    .add(NavMesh3d { nav_mesh, type_index_to_node_type: Default::default() });
+    .add(NavMesh3d { nav_mesh });
 
   app.world_mut().spawn((
     Transform::from_translation(Vec3::new(1.0, 1.0, 1.0)),
@@ -272,7 +272,7 @@ fn draws_avoidance_data_when_requested() {
   let nav_mesh_handle = app
     .world_mut()
     .resource_mut::<Assets<NavMesh3d>>()
-    .add(NavMesh3d { nav_mesh, type_index_to_node_type: Default::default() });
+    .add(NavMesh3d { nav_mesh });
 
   app.world_mut().spawn((Island3dBundle {
     island: Island,

--- a/crates/bevy_landmass/src/island.rs
+++ b/crates/bevy_landmass/src/island.rs
@@ -81,7 +81,6 @@ pub(crate) fn sync_islands_to_archipelago<CS: CoordinateSystem>(
           archipelago.archipelago.add_island(landmass::Island::new(
             landmass_transform,
             island_nav_mesh.nav_mesh.clone(),
-            island_nav_mesh.type_index_to_node_type.clone(),
           ));
         archipelago.islands.insert(island_entity, island_id);
         archipelago.reverse_islands.insert(island_id, island_entity);
@@ -92,13 +91,6 @@ pub(crate) fn sync_islands_to_archipelago<CS: CoordinateSystem>(
         }
         if !Arc::ptr_eq(&island.get_nav_mesh(), &island_nav_mesh.nav_mesh) {
           island.set_nav_mesh(island_nav_mesh.nav_mesh.clone());
-        }
-        if island.get_type_index_to_node_type()
-          != &island_nav_mesh.type_index_to_node_type
-        {
-          island.set_type_index_to_node_type(
-            island_nav_mesh.type_index_to_node_type.clone(),
-          );
         }
       }
     };

--- a/crates/bevy_landmass/src/lib.rs
+++ b/crates/bevy_landmass/src/lib.rs
@@ -24,7 +24,7 @@ mod landmass_structs;
 pub use landmass::{
   AgentOptions, FindPathError, FromAgentRadius, HeightNavigationMesh,
   HeightPolygon, NavigationMesh, NewNodeTypeError, NodeType,
-  PointSampleDistance3d, SamplePointError, SetNodeTypeCostError,
+  PointSampleDistance3d, SamplePointError, SetTypeIndexCostError,
   ValidNavigationMesh, ValidationError,
 };
 
@@ -229,7 +229,7 @@ impl<CS: CoordinateSystem> Archipelago<CS> {
     &mut self,
     node_type: NodeType,
     cost: f32,
-  ) -> Result<(), SetNodeTypeCostError> {
+  ) -> Result<(), SetTypeIndexCostError> {
     self.archipelago.set_node_type_cost(node_type, cost)
   }
 
@@ -455,7 +455,7 @@ impl<CS: CoordinateSystem> SampledPoint<'_, CS> {
   /// Gets the node type of the sampled point. Returns None if the node type
   /// is the default node type.
   pub fn node_type(&self) -> Option<NodeType> {
-    self.sampled_point.node_type()
+    self.sampled_point.type_index()
   }
 }
 

--- a/crates/landmass/README.md
+++ b/crates/landmass/README.md
@@ -77,7 +77,6 @@ let island_id = archipelago
   .add_island(Island::new(
     Transform { translation: Vec3::ZERO, rotation: 0.0 },
     valid_nav_mesh,
-    HashMap::new(),
   ));
 
 let agent_1 = archipelago.add_agent({
@@ -132,8 +131,8 @@ assert!(archipelago
 
 License under either of
 
-* Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
-* MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 
 at your option.
 

--- a/crates/landmass/src/agent_test.rs
+++ b/crates/landmass/src/agent_test.rs
@@ -30,23 +30,23 @@ fn overrides_node_type_costs() {
     /* desired_speed= */ 1.0,
     /* max_speed= */ 1.0,
   );
-  assert!(agent.override_node_type_cost(node_type_1, 3.0));
-  assert!(agent.override_node_type_cost(node_type_2, 0.5));
+  assert!(agent.override_type_index_cost(node_type_1, 3.0));
+  assert!(agent.override_type_index_cost(node_type_2, 0.5));
 
   assert_eq!(
     {
-      let mut vec = agent.get_node_type_cost_overrides().collect::<Vec<_>>();
+      let mut vec = agent.get_type_index_cost_overrides().collect::<Vec<_>>();
       vec.sort_by_key(|&(a, _)| a);
       vec
     },
     [(node_type_1, 3.0), (node_type_2, 0.5)]
   );
 
-  agent.override_node_type_cost(node_type_1, 5.0);
+  agent.override_type_index_cost(node_type_1, 5.0);
 
   assert_eq!(
     {
-      let mut vec = agent.get_node_type_cost_overrides().collect::<Vec<_>>();
+      let mut vec = agent.get_type_index_cost_overrides().collect::<Vec<_>>();
       vec.sort_by_key(|&(a, _)| a);
       vec
     },
@@ -57,7 +57,7 @@ fn overrides_node_type_costs() {
 
   assert_eq!(
     {
-      let mut vec = agent.get_node_type_cost_overrides().collect::<Vec<_>>();
+      let mut vec = agent.get_type_index_cost_overrides().collect::<Vec<_>>();
       vec.sort_by_key(|&(a, _)| a);
       vec
     },
@@ -78,8 +78,8 @@ fn negative_or_zero_node_type_cost_returns_false() {
     /* desired_speed= */ 1.0,
     /* max_speed= */ 1.0,
   );
-  assert!(!agent.override_node_type_cost(node_type, 0.0));
-  assert!(!agent.override_node_type_cost(node_type, -0.5));
+  assert!(!agent.override_type_index_cost(node_type, 0.0));
+  assert!(!agent.override_type_index_cost(node_type, -0.5));
 }
 
 #[test]

--- a/crates/landmass/src/avoidance_test.rs
+++ b/crates/landmass/src/avoidance_test.rs
@@ -90,7 +90,6 @@ fn computes_obstacle_for_box() {
   let island_id = nav_data.add_island(Island::new(
     Transform { translation: island_offset, rotation: 0.0 },
     Arc::new(nav_mesh),
-    HashMap::new(),
   ));
 
   assert_obstacles_match!(
@@ -147,7 +146,6 @@ fn dead_end_makes_open_obstacle() {
   let island_id = nav_data.add_island(Island::new(
     Transform { translation: Vec3::ZERO, rotation: 0.0 },
     Arc::new(nav_mesh),
-    HashMap::new(),
   ));
 
   assert_obstacles_match!(
@@ -291,7 +289,6 @@ fn split_borders() {
   let island_id = nav_data.add_island(Island::new(
     Transform { translation: Vec3::ZERO, rotation: 0.0 },
     Arc::new(nav_mesh),
-    HashMap::new(),
   ));
 
   assert_obstacles_match!(
@@ -351,12 +348,10 @@ fn creates_obstacles_across_boundary_link() {
   nav_data.add_island(Island::new(
     Transform { translation: Vec3::ZERO, rotation: 0.0 },
     Arc::clone(&nav_mesh),
-    HashMap::new(),
   ));
   let island_id_2 = nav_data.add_island(Island::new(
     Transform { translation: Vec3::new(1.0, 0.0, 0.0), rotation: 0.0 },
     nav_mesh,
-    HashMap::new(),
   ));
 
   nav_data.update(0.01);
@@ -411,7 +406,6 @@ fn applies_no_avoidance_for_far_agents() {
   let island_id = nav_data.add_island(Island::new(
     Transform { translation: Vec3::ZERO, rotation: 0.0 },
     Arc::new(nav_mesh),
-    HashMap::new(),
   ));
 
   let mut agents = HopSlotMap::<AgentId, _>::with_key();
@@ -513,7 +507,6 @@ fn applies_avoidance_for_two_agents() {
   let island_id = nav_data.add_island(Island::new(
     Transform { translation: Vec3::ZERO, rotation: 0.0 },
     Arc::new(nav_mesh),
-    HashMap::new(),
   ));
 
   let mut agents = HopSlotMap::<AgentId, _>::with_key();
@@ -609,7 +602,6 @@ fn agent_avoids_character() {
   let island_id = nav_data.add_island(Island::new(
     Transform { translation: Vec3::ZERO, rotation: 0.0 },
     Arc::new(nav_mesh),
-    HashMap::new(),
   ));
 
   let mut agents = HopSlotMap::<AgentId, _>::with_key();
@@ -692,7 +684,6 @@ fn agent_speeds_up_to_avoid_character() {
   let island_id = nav_data.add_island(Island::new(
     Transform { translation: Vec2::ZERO, rotation: 0.0 },
     Arc::new(nav_mesh),
-    HashMap::new(),
   ));
 
   let mut agents = HopSlotMap::<AgentId, _>::with_key();
@@ -792,11 +783,7 @@ fn reached_target_agent_has_different_avoidance() {
     .unwrap(),
   );
 
-  archipelago.add_island(Island::new(
-    Transform::default(),
-    nav_mesh,
-    HashMap::new(),
-  ));
+  archipelago.add_island(Island::new(Transform::default(), nav_mesh));
 
   let agent_1 = archipelago.add_agent({
     let mut agent = Agent::create(
@@ -904,17 +891,13 @@ fn switching_nav_mesh_to_fewer_vertices_does_not_result_in_panic() {
   .unwrap();
   let simplified_mesh = Arc::new(simplified_mesh);
 
-  let island_1 = archipelago.add_island(Island::new(
-    Transform::default(),
-    Arc::clone(&redundant_mesh),
-    HashMap::new(),
-  ));
+  let island_1 = archipelago
+    .add_island(Island::new(Transform::default(), Arc::clone(&redundant_mesh)));
   archipelago.add_island(Island::new(
     // This island is shifted over but is slightly misaligned to generate new
     // vertices.
     Transform { translation: Vec2::new(1.0, 0.25), rotation: 0.0 },
     redundant_mesh,
-    HashMap::new(),
   ));
 
   let agent = archipelago.add_agent({

--- a/crates/landmass/src/debug_test.rs
+++ b/crates/landmass/src/debug_test.rs
@@ -1,4 +1,4 @@
-use std::{cmp::Ordering, collections::HashMap, sync::Arc};
+use std::{cmp::Ordering, sync::Arc};
 
 use glam::Vec3;
 use googletest::{expect_that, matchers::unordered_elements_are};
@@ -103,7 +103,6 @@ fn draws_island_meshes_and_agents() {
   archipelago.add_island(Island::new(
     Transform { translation: TRANSLATION, rotation: 0.0 },
     Arc::new(nav_mesh),
-    HashMap::new(),
   ));
 
   let agent_id = archipelago.add_agent(Agent::create(
@@ -437,15 +436,10 @@ fn draws_boundary_links() {
 
   let mut archipelago =
     Archipelago::<XYZ>::new(AgentOptions::from_agent_radius(0.5));
-  archipelago.add_island(Island::new(
-    Transform::default(),
-    nav_mesh.clone(),
-    HashMap::new(),
-  ));
+  archipelago.add_island(Island::new(Transform::default(), nav_mesh.clone()));
   archipelago.add_island(Island::new(
     Transform { translation: Vec3::new(1.0, 0.0, 0.0), rotation: 0.0 },
     nav_mesh.clone(),
-    HashMap::new(),
   ));
 
   // Update so everything is in sync.
@@ -492,11 +486,8 @@ fn fails_to_draw_dirty_archipelago() {
   assert_eq!(draw_archipelago_debug(&archipelago, &mut fake_drawer), Ok(()));
 
   // Creating an island marks the nav data as dirty.
-  let island_id = archipelago.add_island(Island::new(
-    Transform::default(),
-    nav_mesh.clone(),
-    HashMap::new(),
-  ));
+  let island_id =
+    archipelago.add_island(Island::new(Transform::default(), nav_mesh.clone()));
   assert_eq!(
     draw_archipelago_debug(&archipelago, &mut fake_drawer),
     Err(DebugDrawError::NavDataDirty)
@@ -519,6 +510,7 @@ fn fails_to_draw_dirty_archipelago() {
 fn draws_avoidance_data_when_requested() {
   use glam::Vec2;
   use googletest::{matcher::MatcherResult, prelude::*};
+  use std::collections::HashMap;
 
   use crate::{
     AgentId,
@@ -549,11 +541,7 @@ fn draws_avoidance_data_when_requested() {
     obstacle_avoidance_time_horizon: 100.0,
     ..AgentOptions::from_agent_radius(0.5)
   });
-  archipelago.add_island(Island::new(
-    Transform::default(),
-    nav_mesh.clone(),
-    HashMap::new(),
-  ));
+  archipelago.add_island(Island::new(Transform::default(), nav_mesh.clone()));
 
   let agent_1 = archipelago.add_agent({
     let mut agent = Agent::create(

--- a/crates/landmass/src/island.rs
+++ b/crates/landmass/src/island.rs
@@ -1,9 +1,9 @@
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 use slotmap::new_key_type;
 
 use crate::{
-  CoordinateSystem, NodeType, ValidNavigationMesh,
+  CoordinateSystem, ValidNavigationMesh,
   util::{BoundingBox, Transform},
 };
 
@@ -18,9 +18,6 @@ pub struct Island<CS: CoordinateSystem> {
   pub(crate) transform: Transform<CS>,
   /// The navigation mesh for the island.
   pub(crate) nav_mesh: Arc<ValidNavigationMesh<CS>>,
-  /// A map from the type indices used by [`Self::nav_mesh`] to the
-  /// [`NodeType`]s used in the [`crate::Archipelago`].
-  pub(crate) type_index_to_node_type: HashMap<usize, NodeType>,
 
   /// The bounds of `nav_mesh` after being transformed by `transform`.
   pub(crate) transformed_bounds: BoundingBox,
@@ -29,18 +26,15 @@ pub struct Island<CS: CoordinateSystem> {
 }
 
 impl<CS: CoordinateSystem> Island<CS> {
-  /// Creates a new island. For details on the `type_index_to_node_type`
-  /// argument, see [`Self::set_type_index_to_node_type`].
+  /// Creates a new island.
   pub fn new(
     transform: Transform<CS>,
     nav_mesh: Arc<ValidNavigationMesh<CS>>,
-    type_index_to_node_type: HashMap<usize, NodeType>,
   ) -> Self {
     Self {
       transformed_bounds: nav_mesh.get_bounds().transform(&transform),
       transform,
       nav_mesh,
-      type_index_to_node_type,
       dirty: true,
     }
   }
@@ -71,25 +65,5 @@ impl<CS: CoordinateSystem> Island<CS> {
 
     self.transformed_bounds =
       self.nav_mesh.get_bounds().transform(&self.transform);
-  }
-
-  /// Gets the current `type_index_to_node_type` used by the island.
-  pub fn get_type_index_to_node_type(&self) -> &HashMap<usize, NodeType> {
-    &self.type_index_to_node_type
-  }
-
-  /// Sets the "translation" from the type indices used in the navigation mesh
-  /// into [`NodeType`]s from the [`crate::Archipelago`]. Type indices without a
-  /// corresponding node type will be treated as the "default" node type, which
-  /// has a cost of 1.0. See [`crate::Archipelago::add_node_type`] for
-  /// details on cost. [`NodeType`]s not present in the corresponding
-  /// [`crate::Archipelago`] will cause a panic, so do not mix [`NodeType`]s
-  /// across [`crate::Archipelago`]s.
-  pub fn set_type_index_to_node_type(
-    &mut self,
-    type_index_to_node_type: HashMap<usize, NodeType>,
-  ) {
-    self.type_index_to_node_type = type_index_to_node_type;
-    self.dirty = true;
   }
 }

--- a/crates/landmass/src/lib.rs
+++ b/crates/landmass/src/lib.rs
@@ -174,8 +174,7 @@ impl<CS: CoordinateSystem> Archipelago<CS> {
 
   /// Sets the cost of `type_index` to `cost`. The cost is a multiplier on the
   /// distance travelled along this node (essentially the cost per meter).
-  /// Agents will prefer to travel along low-cost terrain. This node type is
-  /// distinct from all other node types.
+  /// Agents will prefer to travel along low-cost terrain.
   pub fn set_type_index_cost(
     &mut self,
     type_index: usize,
@@ -189,7 +188,7 @@ impl<CS: CoordinateSystem> Archipelago<CS> {
     self.nav_data.get_type_index_cost(type_index)
   }
 
-  /// Gets the current node types and their costs.
+  /// Gets the current registered type indices and their costs.
   pub fn get_type_index_costs(
     &self,
   ) -> impl Iterator<Item = (usize, f32)> + '_ {

--- a/crates/landmass/src/lib_test.rs
+++ b/crates/landmass/src/lib_test.rs
@@ -746,7 +746,7 @@ fn agent_overrides_node_costs() {
       /* desired_speed= */ 1.0,
       /* max_speed= */ 1.0,
     );
-    assert!(agent.override_node_type_cost(node_type, 10.0));
+    assert!(agent.override_type_index_cost(node_type, 10.0));
     agent.current_target = Some(Vec2::new(0.5, 11.5));
     agent
   });

--- a/crates/landmass/src/lib_test.rs
+++ b/crates/landmass/src/lib_test.rs
@@ -184,7 +184,6 @@ fn computes_and_follows_path() {
   archipelago.add_island(Island::new(
     Transform { translation: Vec3::ZERO, rotation: 0.0 },
     Arc::new(nav_mesh),
-    HashMap::new(),
   ));
 
   archipelago.agent_options.neighbourhood = 0.0;
@@ -436,11 +435,7 @@ fn agent_speeds_up_to_avoid_character() {
     .expect("Validation succeeded."),
   );
 
-  archipelago.add_island(Island::new(
-    Transform::default(),
-    nav_mesh,
-    HashMap::new(),
-  ));
+  archipelago.add_island(Island::new(Transform::default(), nav_mesh));
 
   let agent_id = archipelago.add_agent({
     let mut agent = Agent::create(
@@ -494,21 +489,12 @@ fn add_and_remove_islands() {
     .unwrap(),
   );
 
-  let island_id_1 = archipelago.add_island(Island::new(
-    Transform::default(),
-    nav_mesh.clone(),
-    Default::default(),
-  ));
-  let island_id_2 = archipelago.add_island(Island::new(
-    Transform::default(),
-    nav_mesh.clone(),
-    Default::default(),
-  ));
-  let island_id_3 = archipelago.add_island(Island::new(
-    Transform::default(),
-    nav_mesh.clone(),
-    Default::default(),
-  ));
+  let island_id_1 =
+    archipelago.add_island(Island::new(Transform::default(), nav_mesh.clone()));
+  let island_id_2 =
+    archipelago.add_island(Island::new(Transform::default(), nav_mesh.clone()));
+  let island_id_3 =
+    archipelago.add_island(Island::new(Transform::default(), nav_mesh.clone()));
 
   fn sorted(mut v: Vec<IslandId>) -> Vec<IslandId> {
     v.sort();
@@ -545,7 +531,6 @@ fn changed_island_is_not_dirty_after_update() {
       .validate()
       .unwrap(),
     ),
-    HashMap::new(),
   ));
 
   assert!(archipelago.get_island(island_id).unwrap().dirty);
@@ -591,7 +576,6 @@ fn samples_point() {
   archipelago.add_island(Island::new(
     Transform { translation: offset, rotation: 0.0 },
     nav_mesh,
-    HashMap::new(),
   ));
   archipelago.update(1.0);
 
@@ -649,17 +633,14 @@ fn finds_path() {
   archipelago.add_island(Island::new(
     Transform { translation: offset, rotation: 0.0 },
     nav_mesh.clone(),
-    HashMap::new(),
   ));
   archipelago.add_island(Island::new(
     Transform { translation: offset + Vec2::new(1.0, 0.0), rotation: 0.0 },
     nav_mesh.clone(),
-    HashMap::new(),
   ));
   archipelago.add_island(Island::new(
     Transform { translation: offset + Vec2::new(2.0, 0.5), rotation: 0.0 },
     nav_mesh,
-    HashMap::new(),
   ));
   archipelago.update(1.0);
 
@@ -730,13 +711,9 @@ fn agent_overrides_node_costs() {
     .expect("nav mesh is valid"),
   );
 
-  let node_type = archipelago.add_node_type(1.0).unwrap();
+  archipelago.set_type_index_cost(1, 1.0).unwrap();
 
-  archipelago.add_island(Island::new(
-    Transform::default(),
-    nav_mesh,
-    HashMap::from([(1, node_type)]),
-  ));
+  archipelago.add_island(Island::new(Transform::default(), nav_mesh));
 
   let agent_id = archipelago.add_agent({
     let mut agent = Agent::create(
@@ -746,7 +723,7 @@ fn agent_overrides_node_costs() {
       /* desired_speed= */ 1.0,
       /* max_speed= */ 1.0,
     );
-    assert!(agent.override_type_index_cost(node_type, 10.0));
+    assert!(agent.override_type_index_cost(1, 10.0));
     agent.current_target = Some(Vec2::new(0.5, 11.5));
     agent
   });

--- a/crates/landmass/src/nav_data.rs
+++ b/crates/landmass/src/nav_data.rs
@@ -115,8 +115,7 @@ impl<CS: CoordinateSystem> NavigationData<CS> {
 
   /// Sets the cost of `type_index` to `cost`. The cost is a multiplier on the
   /// distance travelled along this node (essentially the cost per meter).
-  /// Agents will prefer to travel along low-cost terrain. This node type is
-  /// distinct from all other node types.
+  /// Agents will prefer to travel along low-cost terrain.
   pub(crate) fn set_type_index_cost(
     &mut self,
     type_index: usize,
@@ -134,7 +133,7 @@ impl<CS: CoordinateSystem> NavigationData<CS> {
     self.type_index_to_cost.get(&type_index).copied()
   }
 
-  /// Gets the current node types and their costs.
+  /// Gets the current type indices and their costs.
   pub(crate) fn get_type_index_costs(
     &self,
   ) -> impl Iterator<Item = (usize, f32)> + '_ {

--- a/crates/landmass/src/nav_data_test.rs
+++ b/crates/landmass/src/nav_data_test.rs
@@ -10,7 +10,7 @@ use slotmap::{HopSlotMap, SlotMap};
 
 use crate::{
   AgentOptions, Archipelago, FromAgentRadius, IslandId, NewNodeTypeError,
-  NodeType, PointSampleDistance3d, SetNodeTypeCostError, Transform,
+  NodeType, PointSampleDistance3d, SetTypeIndexCostError, Transform,
   coords::{XY, XYZ},
   island::Island,
   nav_data::{BoundaryLink, NodeRef},
@@ -144,7 +144,7 @@ fn clone_sort_round_links(
           .map(|link_id| boundary_links.get(*link_id).unwrap())
           .map(|link| BoundaryLink {
             destination_node: link.destination_node,
-            destination_node_type: link.destination_node_type,
+            destination_type_index: link.destination_type_index,
             portal: (
               (link.portal.0 / round_amount).round() * round_amount,
               (link.portal.1 / round_amount).round() * round_amount,
@@ -284,7 +284,7 @@ fn link_edges_between_islands_links_touching_islands() {
       NodeRef { island_id: island_1_id, polygon_index: 0 },
       vec![BoundaryLink {
         destination_node: NodeRef { island_id: island_2_id, polygon_index: 2 },
-        destination_node_type: None,
+        destination_type_index: None,
         portal: transform_and_round_portal(
           &transform,
           Vec3::new(1.0, 0.5, 1.0),
@@ -297,7 +297,7 @@ fn link_edges_between_islands_links_touching_islands() {
       NodeRef { island_id: island_1_id, polygon_index: 1 },
       vec![BoundaryLink {
         destination_node: NodeRef { island_id: island_2_id, polygon_index: 3 },
-        destination_node_type: None,
+        destination_type_index: None,
         portal: transform_and_round_portal(
           &transform,
           Vec3::new(-0.5, 1.0, 1.0),
@@ -310,7 +310,7 @@ fn link_edges_between_islands_links_touching_islands() {
       NodeRef { island_id: island_1_id, polygon_index: 2 },
       vec![BoundaryLink {
         destination_node: NodeRef { island_id: island_2_id, polygon_index: 0 },
-        destination_node_type: None,
+        destination_type_index: None,
         portal: transform_and_round_portal(
           &transform,
           Vec3::new(-1.0, 0.0, 1.0),
@@ -323,7 +323,7 @@ fn link_edges_between_islands_links_touching_islands() {
       NodeRef { island_id: island_1_id, polygon_index: 3 },
       vec![BoundaryLink {
         destination_node: NodeRef { island_id: island_2_id, polygon_index: 0 },
-        destination_node_type: None,
+        destination_type_index: None,
         portal: transform_and_round_portal(
           &transform,
           Vec3::new(-1.0, -0.5, 1.0),
@@ -336,7 +336,7 @@ fn link_edges_between_islands_links_touching_islands() {
       NodeRef { island_id: island_1_id, polygon_index: 4 },
       vec![BoundaryLink {
         destination_node: NodeRef { island_id: island_2_id, polygon_index: 4 },
-        destination_node_type: Some(node_type_2),
+        destination_type_index: Some(node_type_2),
         portal: transform_and_round_portal(
           &transform,
           Vec3::new(0.5, -1.0, 1.0),
@@ -349,7 +349,7 @@ fn link_edges_between_islands_links_touching_islands() {
       NodeRef { island_id: island_1_id, polygon_index: 5 },
       vec![BoundaryLink {
         destination_node: NodeRef { island_id: island_2_id, polygon_index: 2 },
-        destination_node_type: None,
+        destination_type_index: None,
         portal: transform_and_round_portal(
           &transform,
           Vec3::new(1.0, 0.0, 1.0),
@@ -367,7 +367,7 @@ fn link_edges_between_islands_links_touching_islands() {
             island_id: island_1_id,
             polygon_index: 2,
           },
-          destination_node_type: Some(node_type_1),
+          destination_type_index: Some(node_type_1),
           portal: transform_and_round_portal(
             &transform,
             Vec3::new(-1.0, 0.5, 1.0),
@@ -380,7 +380,7 @@ fn link_edges_between_islands_links_touching_islands() {
             island_id: island_1_id,
             polygon_index: 3,
           },
-          destination_node_type: Some(node_type_1),
+          destination_type_index: Some(node_type_1),
           portal: transform_and_round_portal(
             &transform,
             Vec3::new(-1.0, 0.0, 1.0),
@@ -398,7 +398,7 @@ fn link_edges_between_islands_links_touching_islands() {
             island_id: island_1_id,
             polygon_index: 0,
           },
-          destination_node_type: None,
+          destination_type_index: None,
           portal: transform_and_round_portal(
             &transform,
             Vec3::new(1.0, 0.0, 1.0),
@@ -411,7 +411,7 @@ fn link_edges_between_islands_links_touching_islands() {
             island_id: island_1_id,
             polygon_index: 5,
           },
-          destination_node_type: None,
+          destination_type_index: None,
           portal: transform_and_round_portal(
             &transform,
             Vec3::new(1.0, -0.5, 1.0),
@@ -425,7 +425,7 @@ fn link_edges_between_islands_links_touching_islands() {
       NodeRef { island_id: island_2_id, polygon_index: 3 },
       vec![BoundaryLink {
         destination_node: NodeRef { island_id: island_1_id, polygon_index: 1 },
-        destination_node_type: Some(node_type_1),
+        destination_type_index: Some(node_type_1),
         portal: transform_and_round_portal(
           &transform,
           Vec3::new(0.5, 1.0, 1.0),
@@ -438,7 +438,7 @@ fn link_edges_between_islands_links_touching_islands() {
       NodeRef { island_id: island_2_id, polygon_index: 4 },
       vec![BoundaryLink {
         destination_node: NodeRef { island_id: island_1_id, polygon_index: 4 },
-        destination_node_type: None,
+        destination_type_index: None,
         portal: transform_and_round_portal(
           &transform,
           Vec3::new(-0.5, -1.0, 1.0),
@@ -568,7 +568,7 @@ fn update_links_islands_and_unlinks_on_delete() {
               island_id: island_4_id,
               polygon_index: 0,
             },
-            destination_node_type: None,
+            destination_type_index: None,
             portal: (Vec3::new(1.0, 0.0, 1.0), Vec3::new(2.0, 0.0, 1.0)),
             reverse_link: Default::default(),
           },
@@ -577,7 +577,7 @@ fn update_links_islands_and_unlinks_on_delete() {
               island_id: island_5_id,
               polygon_index: 0,
             },
-            destination_node_type: None,
+            destination_type_index: None,
             portal: (Vec3::new(2.0, 1.0, 1.0), Vec3::new(2.0, 2.0, 1.0)),
             reverse_link: Default::default(),
           },
@@ -590,7 +590,7 @@ fn update_links_islands_and_unlinks_on_delete() {
             island_id: island_2_id,
             polygon_index: 0,
           },
-          destination_node_type: None,
+          destination_type_index: None,
           portal: (Vec3::new(0.0, 2.0, 1.0), Vec3::new(0.0, 1.0, 1.0)),
           reverse_link: Default::default(),
         }],
@@ -602,7 +602,7 @@ fn update_links_islands_and_unlinks_on_delete() {
             island_id: island_1_id,
             polygon_index: 1,
           },
-          destination_node_type: None,
+          destination_type_index: None,
           portal: (Vec3::new(0.0, 1.0, 1.0), Vec3::new(0.0, 2.0, 1.0)),
           reverse_link: Default::default(),
         }],
@@ -614,7 +614,7 @@ fn update_links_islands_and_unlinks_on_delete() {
             island_id: island_3_id,
             polygon_index: 0,
           },
-          destination_node_type: None,
+          destination_type_index: None,
           portal: (Vec3::new(-2.0, 0.0, 1.0), Vec3::new(-1.0, 0.0, 1.0)),
           reverse_link: Default::default(),
         }],
@@ -626,7 +626,7 @@ fn update_links_islands_and_unlinks_on_delete() {
             island_id: island_2_id,
             polygon_index: 1,
           },
-          destination_node_type: None,
+          destination_type_index: None,
           portal: (Vec3::new(-1.0, 0.0, 1.0), Vec3::new(-2.0, 0.0, 1.0)),
           reverse_link: Default::default(),
         }],
@@ -638,7 +638,7 @@ fn update_links_islands_and_unlinks_on_delete() {
             island_id: island_1_id,
             polygon_index: 0,
           },
-          destination_node_type: None,
+          destination_type_index: None,
           portal: (Vec3::new(2.0, 0.0, 1.0), Vec3::new(1.0, 0.0, 1.0)),
           reverse_link: Default::default(),
         }],
@@ -650,7 +650,7 @@ fn update_links_islands_and_unlinks_on_delete() {
             island_id: island_1_id,
             polygon_index: 0,
           },
-          destination_node_type: None,
+          destination_type_index: None,
           portal: (Vec3::new(2.0, 2.0, 1.0), Vec3::new(2.0, 1.0, 1.0)),
           reverse_link: Default::default(),
         }],
@@ -685,7 +685,7 @@ fn update_links_islands_and_unlinks_on_delete() {
             island_id: island_5_id,
             polygon_index: 0,
           },
-          destination_node_type: None,
+          destination_type_index: None,
           portal: (Vec3::new(0.0, 2.0, 1.0), Vec3::new(0.0, 1.0, 1.0)),
           reverse_link: Default::default(),
         }],
@@ -697,7 +697,7 @@ fn update_links_islands_and_unlinks_on_delete() {
             island_id: island_5_id,
             polygon_index: 1,
           },
-          destination_node_type: None,
+          destination_type_index: None,
           portal: (Vec3::new(-1.0, 0.0, 1.0), Vec3::new(-2.0, 0.0, 1.0)),
           reverse_link: Default::default(),
         }],
@@ -709,7 +709,7 @@ fn update_links_islands_and_unlinks_on_delete() {
             island_id: island_1_id,
             polygon_index: 1,
           },
-          destination_node_type: None,
+          destination_type_index: None,
           portal: (Vec3::new(0.0, 1.0, 1.0), Vec3::new(0.0, 2.0, 1.0)),
           reverse_link: Default::default(),
         }],
@@ -721,7 +721,7 @@ fn update_links_islands_and_unlinks_on_delete() {
             island_id: island_3_id,
             polygon_index: 0,
           },
-          destination_node_type: None,
+          destination_type_index: None,
           portal: (Vec3::new(-2.0, 0.0, 1.0), Vec3::new(-1.0, 0.0, 1.0)),
           reverse_link: Default::default(),
         }],
@@ -982,11 +982,11 @@ fn false_on_setting_zero_or_negative_node_type() {
 
   assert_eq!(
     archipelago.set_node_type_cost(node_type, 0.0),
-    Err(SetNodeTypeCostError::NonPositiveCost(0.0))
+    Err(SetTypeIndexCostError::NonPositiveCost(0.0))
   );
   assert_eq!(
     archipelago.set_node_type_cost(node_type, -1.0),
-    Err(SetNodeTypeCostError::NonPositiveCost(-1.0))
+    Err(SetTypeIndexCostError::NonPositiveCost(-1.0))
   );
 }
 
@@ -1034,14 +1034,14 @@ fn cannot_remove_used_node_type() {
   ));
 
   assert_eq!(
-    archipelago.nav_data.get_node_types().collect::<Vec<_>>(),
+    archipelago.nav_data.get_type_index_costs().collect::<Vec<_>>(),
     [(node_type_1, 2.0), (node_type_2, 3.0)]
   );
 
   // Two islands still reference `node_type_1`.
   assert!(!archipelago.remove_node_type(node_type_1));
   assert_eq!(
-    archipelago.nav_data.get_node_types().collect::<Vec<_>>(),
+    archipelago.nav_data.get_type_index_costs().collect::<Vec<_>>(),
     [(node_type_1, 2.0), (node_type_2, 3.0)]
   );
 
@@ -1049,7 +1049,7 @@ fn cannot_remove_used_node_type() {
   // One island still references `node_type_1`.
   assert!(!archipelago.remove_node_type(node_type_1));
   assert_eq!(
-    archipelago.nav_data.get_node_types().collect::<Vec<_>>(),
+    archipelago.nav_data.get_type_index_costs().collect::<Vec<_>>(),
     [(node_type_1, 2.0), (node_type_2, 3.0)]
   );
 
@@ -1061,7 +1061,7 @@ fn cannot_remove_used_node_type() {
   assert!(!archipelago.remove_node_type(node_type_1));
 
   assert_eq!(
-    archipelago.nav_data.get_node_types().collect::<Vec<_>>(),
+    archipelago.nav_data.get_type_index_costs().collect::<Vec<_>>(),
     [(node_type_2, 3.0)]
   );
 }

--- a/crates/landmass/src/nav_data_test.rs
+++ b/crates/landmass/src/nav_data_test.rs
@@ -9,8 +9,8 @@ use glam::{Vec2, Vec3};
 use slotmap::{HopSlotMap, SlotMap};
 
 use crate::{
-  AgentOptions, Archipelago, FromAgentRadius, IslandId, NewNodeTypeError,
-  NodeType, PointSampleDistance3d, SetTypeIndexCostError, Transform,
+  AgentOptions, Archipelago, FromAgentRadius, IslandId, PointSampleDistance3d,
+  SetTypeIndexCostError, Transform,
   coords::{XY, XYZ},
   island::Island,
   nav_data::{BoundaryLink, NodeRef},
@@ -47,12 +47,10 @@ fn samples_points() {
   let island_id_1 = nav_data.add_island(Island::new(
     Transform { translation: Vec3::ZERO, rotation: 0.0 },
     Arc::clone(&nav_mesh),
-    HashMap::new(),
   ));
   let island_id_2 = nav_data.add_island(Island::new(
     Transform { translation: Vec3::new(5.0, 0.0, 0.1), rotation: PI * 0.5 },
     Arc::clone(&nav_mesh),
-    HashMap::new(),
   ));
 
   // Just above island 1 node.
@@ -222,7 +220,7 @@ fn link_edges_between_islands_links_touching_islands() {
         vec![5, 6, 9, 8],
         vec![10, 11, 2, 1],
       ],
-      polygon_type_indices: vec![0, 0, 0, 0, 1],
+      polygon_type_indices: vec![0, 0, 0, 0, 2],
       height_mesh: None,
     }
     .validate()
@@ -233,23 +231,12 @@ fn link_edges_between_islands_links_touching_islands() {
   let mut slotmap = HopSlotMap::<IslandId, _>::with_key();
   let island_1_id = slotmap.insert(0);
   let island_2_id = slotmap.insert(0);
-  let mut slotmap = SlotMap::<NodeType, _>::with_key();
-  let node_type_1 = slotmap.insert(0);
-  let node_type_2 = slotmap.insert(0);
 
   let transform =
     Transform { translation: Vec3::new(1.0, 2.0, 3.0), rotation: PI * -0.25 };
 
-  let island_1 = Island::new(
-    transform.clone(),
-    Arc::clone(&nav_mesh_1),
-    HashMap::from([(1, node_type_1)]),
-  );
-  let island_2 = Island::new(
-    transform.clone(),
-    Arc::clone(&nav_mesh_2),
-    HashMap::from([(1, node_type_2)]),
-  );
+  let island_1 = Island::new(transform.clone(), Arc::clone(&nav_mesh_1));
+  let island_2 = Island::new(transform.clone(), Arc::clone(&nav_mesh_2));
 
   let island_1_edge_bbh = island_edges_bbh(&island_1);
   let island_2_edge_bbh = island_edges_bbh(&island_2);
@@ -284,7 +271,7 @@ fn link_edges_between_islands_links_touching_islands() {
       NodeRef { island_id: island_1_id, polygon_index: 0 },
       vec![BoundaryLink {
         destination_node: NodeRef { island_id: island_2_id, polygon_index: 2 },
-        destination_type_index: None,
+        destination_type_index: 0,
         portal: transform_and_round_portal(
           &transform,
           Vec3::new(1.0, 0.5, 1.0),
@@ -297,7 +284,7 @@ fn link_edges_between_islands_links_touching_islands() {
       NodeRef { island_id: island_1_id, polygon_index: 1 },
       vec![BoundaryLink {
         destination_node: NodeRef { island_id: island_2_id, polygon_index: 3 },
-        destination_type_index: None,
+        destination_type_index: 0,
         portal: transform_and_round_portal(
           &transform,
           Vec3::new(-0.5, 1.0, 1.0),
@@ -310,7 +297,7 @@ fn link_edges_between_islands_links_touching_islands() {
       NodeRef { island_id: island_1_id, polygon_index: 2 },
       vec![BoundaryLink {
         destination_node: NodeRef { island_id: island_2_id, polygon_index: 0 },
-        destination_type_index: None,
+        destination_type_index: 0,
         portal: transform_and_round_portal(
           &transform,
           Vec3::new(-1.0, 0.0, 1.0),
@@ -323,7 +310,7 @@ fn link_edges_between_islands_links_touching_islands() {
       NodeRef { island_id: island_1_id, polygon_index: 3 },
       vec![BoundaryLink {
         destination_node: NodeRef { island_id: island_2_id, polygon_index: 0 },
-        destination_type_index: None,
+        destination_type_index: 0,
         portal: transform_and_round_portal(
           &transform,
           Vec3::new(-1.0, -0.5, 1.0),
@@ -336,7 +323,7 @@ fn link_edges_between_islands_links_touching_islands() {
       NodeRef { island_id: island_1_id, polygon_index: 4 },
       vec![BoundaryLink {
         destination_node: NodeRef { island_id: island_2_id, polygon_index: 4 },
-        destination_type_index: Some(node_type_2),
+        destination_type_index: 2,
         portal: transform_and_round_portal(
           &transform,
           Vec3::new(0.5, -1.0, 1.0),
@@ -349,7 +336,7 @@ fn link_edges_between_islands_links_touching_islands() {
       NodeRef { island_id: island_1_id, polygon_index: 5 },
       vec![BoundaryLink {
         destination_node: NodeRef { island_id: island_2_id, polygon_index: 2 },
-        destination_type_index: None,
+        destination_type_index: 0,
         portal: transform_and_round_portal(
           &transform,
           Vec3::new(1.0, 0.0, 1.0),
@@ -367,7 +354,7 @@ fn link_edges_between_islands_links_touching_islands() {
             island_id: island_1_id,
             polygon_index: 2,
           },
-          destination_type_index: Some(node_type_1),
+          destination_type_index: 1,
           portal: transform_and_round_portal(
             &transform,
             Vec3::new(-1.0, 0.5, 1.0),
@@ -380,7 +367,7 @@ fn link_edges_between_islands_links_touching_islands() {
             island_id: island_1_id,
             polygon_index: 3,
           },
-          destination_type_index: Some(node_type_1),
+          destination_type_index: 1,
           portal: transform_and_round_portal(
             &transform,
             Vec3::new(-1.0, 0.0, 1.0),
@@ -398,7 +385,7 @@ fn link_edges_between_islands_links_touching_islands() {
             island_id: island_1_id,
             polygon_index: 0,
           },
-          destination_type_index: None,
+          destination_type_index: 0,
           portal: transform_and_round_portal(
             &transform,
             Vec3::new(1.0, 0.0, 1.0),
@@ -411,7 +398,7 @@ fn link_edges_between_islands_links_touching_islands() {
             island_id: island_1_id,
             polygon_index: 5,
           },
-          destination_type_index: None,
+          destination_type_index: 0,
           portal: transform_and_round_portal(
             &transform,
             Vec3::new(1.0, -0.5, 1.0),
@@ -425,7 +412,7 @@ fn link_edges_between_islands_links_touching_islands() {
       NodeRef { island_id: island_2_id, polygon_index: 3 },
       vec![BoundaryLink {
         destination_node: NodeRef { island_id: island_1_id, polygon_index: 1 },
-        destination_type_index: Some(node_type_1),
+        destination_type_index: 1,
         portal: transform_and_round_portal(
           &transform,
           Vec3::new(0.5, 1.0, 1.0),
@@ -438,7 +425,7 @@ fn link_edges_between_islands_links_touching_islands() {
       NodeRef { island_id: island_2_id, polygon_index: 4 },
       vec![BoundaryLink {
         destination_node: NodeRef { island_id: island_1_id, polygon_index: 4 },
-        destination_type_index: None,
+        destination_type_index: 0,
         portal: transform_and_round_portal(
           &transform,
           Vec3::new(-0.5, -1.0, 1.0),
@@ -527,27 +514,22 @@ fn update_links_islands_and_unlinks_on_delete() {
   let island_1_id = nav_data.add_island(Island::new(
     Transform { translation: Vec3::ZERO, rotation: 0.0 },
     Arc::clone(&nav_mesh),
-    HashMap::new(),
   ));
   let island_2_id = nav_data.add_island(Island::new(
     Transform { translation: Vec3::ZERO, rotation: PI * 0.5 },
     Arc::clone(&nav_mesh),
-    HashMap::new(),
   ));
   let island_3_id = nav_data.add_island(Island::new(
     Transform { translation: Vec3::ZERO, rotation: PI },
     Arc::clone(&nav_mesh),
-    HashMap::new(),
   ));
   let island_4_id = nav_data.add_island(Island::new(
     Transform { translation: Vec3::new(3.0, 0.0, 0.0), rotation: PI },
     Arc::clone(&nav_mesh),
-    HashMap::new(),
   ));
   let island_5_id = nav_data.add_island(Island::new(
     Transform { translation: Vec3::new(2.0, 3.0, 0.0), rotation: PI * -0.5 },
     Arc::clone(&nav_mesh),
-    HashMap::new(),
   ));
 
   nav_data.update(/* edge_link_distance= */ 0.01);
@@ -568,7 +550,7 @@ fn update_links_islands_and_unlinks_on_delete() {
               island_id: island_4_id,
               polygon_index: 0,
             },
-            destination_type_index: None,
+            destination_type_index: 0,
             portal: (Vec3::new(1.0, 0.0, 1.0), Vec3::new(2.0, 0.0, 1.0)),
             reverse_link: Default::default(),
           },
@@ -577,7 +559,7 @@ fn update_links_islands_and_unlinks_on_delete() {
               island_id: island_5_id,
               polygon_index: 0,
             },
-            destination_type_index: None,
+            destination_type_index: 0,
             portal: (Vec3::new(2.0, 1.0, 1.0), Vec3::new(2.0, 2.0, 1.0)),
             reverse_link: Default::default(),
           },
@@ -590,7 +572,7 @@ fn update_links_islands_and_unlinks_on_delete() {
             island_id: island_2_id,
             polygon_index: 0,
           },
-          destination_type_index: None,
+          destination_type_index: 0,
           portal: (Vec3::new(0.0, 2.0, 1.0), Vec3::new(0.0, 1.0, 1.0)),
           reverse_link: Default::default(),
         }],
@@ -602,7 +584,7 @@ fn update_links_islands_and_unlinks_on_delete() {
             island_id: island_1_id,
             polygon_index: 1,
           },
-          destination_type_index: None,
+          destination_type_index: 0,
           portal: (Vec3::new(0.0, 1.0, 1.0), Vec3::new(0.0, 2.0, 1.0)),
           reverse_link: Default::default(),
         }],
@@ -614,7 +596,7 @@ fn update_links_islands_and_unlinks_on_delete() {
             island_id: island_3_id,
             polygon_index: 0,
           },
-          destination_type_index: None,
+          destination_type_index: 0,
           portal: (Vec3::new(-2.0, 0.0, 1.0), Vec3::new(-1.0, 0.0, 1.0)),
           reverse_link: Default::default(),
         }],
@@ -626,7 +608,7 @@ fn update_links_islands_and_unlinks_on_delete() {
             island_id: island_2_id,
             polygon_index: 1,
           },
-          destination_type_index: None,
+          destination_type_index: 0,
           portal: (Vec3::new(-1.0, 0.0, 1.0), Vec3::new(-2.0, 0.0, 1.0)),
           reverse_link: Default::default(),
         }],
@@ -638,7 +620,7 @@ fn update_links_islands_and_unlinks_on_delete() {
             island_id: island_1_id,
             polygon_index: 0,
           },
-          destination_type_index: None,
+          destination_type_index: 0,
           portal: (Vec3::new(2.0, 0.0, 1.0), Vec3::new(1.0, 0.0, 1.0)),
           reverse_link: Default::default(),
         }],
@@ -650,7 +632,7 @@ fn update_links_islands_and_unlinks_on_delete() {
             island_id: island_1_id,
             polygon_index: 0,
           },
-          destination_type_index: None,
+          destination_type_index: 0,
           portal: (Vec3::new(2.0, 2.0, 1.0), Vec3::new(2.0, 1.0, 1.0)),
           reverse_link: Default::default(),
         }],
@@ -685,7 +667,7 @@ fn update_links_islands_and_unlinks_on_delete() {
             island_id: island_5_id,
             polygon_index: 0,
           },
-          destination_type_index: None,
+          destination_type_index: 0,
           portal: (Vec3::new(0.0, 2.0, 1.0), Vec3::new(0.0, 1.0, 1.0)),
           reverse_link: Default::default(),
         }],
@@ -697,7 +679,7 @@ fn update_links_islands_and_unlinks_on_delete() {
             island_id: island_5_id,
             polygon_index: 1,
           },
-          destination_type_index: None,
+          destination_type_index: 0,
           portal: (Vec3::new(-1.0, 0.0, 1.0), Vec3::new(-2.0, 0.0, 1.0)),
           reverse_link: Default::default(),
         }],
@@ -709,7 +691,7 @@ fn update_links_islands_and_unlinks_on_delete() {
             island_id: island_1_id,
             polygon_index: 1,
           },
-          destination_type_index: None,
+          destination_type_index: 0,
           portal: (Vec3::new(0.0, 1.0, 1.0), Vec3::new(0.0, 2.0, 1.0)),
           reverse_link: Default::default(),
         }],
@@ -721,7 +703,7 @@ fn update_links_islands_and_unlinks_on_delete() {
             island_id: island_3_id,
             polygon_index: 0,
           },
-          destination_type_index: None,
+          destination_type_index: 0,
           portal: (Vec3::new(-2.0, 0.0, 1.0), Vec3::new(-1.0, 0.0, 1.0)),
           reverse_link: Default::default(),
         }],
@@ -823,17 +805,14 @@ fn modifies_node_boundaries_for_linked_islands() {
   let island_1_id = nav_data.add_island(Island::new(
     Transform { translation: Vec3::ZERO, rotation: 0.0 },
     Arc::clone(&nav_mesh),
-    HashMap::new(),
   ));
   let island_2_id = nav_data.add_island(Island::new(
     Transform { translation: Vec3::new(1.0, -1.0, 0.0), rotation: 0.0 },
     Arc::clone(&nav_mesh),
-    HashMap::new(),
   ));
   let island_3_id = nav_data.add_island(Island::new(
     Transform { translation: Vec3::new(2.0, 3.5, 0.0), rotation: PI * -0.5 },
     Arc::clone(&nav_mesh),
-    HashMap::new(),
   ));
 
   nav_data.update(/* edge_link_distance= */ 1e-6);
@@ -895,12 +874,10 @@ fn stale_modified_nodes_are_removed() {
   nav_data.add_island(Island::new(
     Transform { translation: Vec3::ZERO, rotation: 0.0 },
     Arc::clone(&nav_mesh),
-    HashMap::new(),
   ));
   let island_2_id = nav_data.add_island(Island::new(
     Transform { translation: Vec3::new(1.0, -1.0, 0.0), rotation: 0.0 },
     Arc::clone(&nav_mesh),
-    HashMap::new(),
   ));
 
   nav_data.update(/* edge_link_distance= */ 1e-6);
@@ -944,16 +921,8 @@ fn empty_navigation_mesh_is_safe() {
   );
 
   let mut nav_data = NavigationData::<XYZ>::new();
-  nav_data.add_island(Island::new(
-    Transform::default(),
-    full_nav_mesh,
-    HashMap::new(),
-  ));
-  nav_data.add_island(Island::new(
-    Transform::default(),
-    empty_nav_mesh,
-    HashMap::new(),
-  ));
+  nav_data.add_island(Island::new(Transform::default(), full_nav_mesh));
+  nav_data.add_island(Island::new(Transform::default(), empty_nav_mesh));
 
   // Nothing should panic here.
   nav_data.update(/* edge_link_distance= */ 1e-6);
@@ -964,138 +933,11 @@ fn error_on_create_zero_or_negative_node_type() {
   let mut archipelago =
     Archipelago::<XY>::new(AgentOptions::from_agent_radius(0.5));
   assert_eq!(
-    archipelago.add_node_type(0.0),
-    Err(NewNodeTypeError::NonPositiveCost(0.0))
-  );
-  assert_eq!(
-    archipelago.add_node_type(-1.0),
-    Err(NewNodeTypeError::NonPositiveCost(-1.0))
-  );
-}
-
-#[test]
-fn false_on_setting_zero_or_negative_node_type() {
-  let mut archipelago =
-    Archipelago::<XY>::new(AgentOptions::from_agent_radius(0.5));
-
-  let node_type = archipelago.add_node_type(1.0).unwrap();
-
-  assert_eq!(
-    archipelago.set_node_type_cost(node_type, 0.0),
+    archipelago.set_type_index_cost(0, 0.0),
     Err(SetTypeIndexCostError::NonPositiveCost(0.0))
   );
   assert_eq!(
-    archipelago.set_node_type_cost(node_type, -1.0),
+    archipelago.set_type_index_cost(0, -1.0),
     Err(SetTypeIndexCostError::NonPositiveCost(-1.0))
   );
-}
-
-#[test]
-fn cannot_remove_used_node_type() {
-  let mut archipelago =
-    Archipelago::<XY>::new(AgentOptions::from_agent_radius(0.5));
-
-  let node_type_1 = archipelago.add_node_type(2.0).unwrap();
-  let node_type_2 = archipelago.add_node_type(3.0).unwrap();
-
-  let nav_mesh = Arc::new(
-    NavigationMesh {
-      vertices: vec![
-        Vec2::new(0.0, 0.0),
-        Vec2::new(1.0, 0.0),
-        Vec2::new(1.0, 1.0),
-        Vec2::new(0.0, 1.0),
-      ],
-      polygons: vec![vec![0, 1, 2, 3]],
-      polygon_type_indices: vec![0],
-      height_mesh: None,
-    }
-    .validate()
-    .expect("mesh is valid"),
-  );
-
-  let island_id_1 = archipelago.add_island(Island::new(
-    Transform::default(),
-    nav_mesh.clone(),
-    HashMap::from([(0, node_type_1)]),
-  ));
-
-  let island_id_2 = archipelago.add_island(Island::new(
-    Transform::default(),
-    nav_mesh.clone(),
-    HashMap::from([(0, node_type_1)]),
-  ));
-
-  // Another island that has no effect since it doesn't mention `node_type_1`.
-  archipelago.add_island(Island::new(
-    Transform::default(),
-    nav_mesh.clone(),
-    HashMap::from([(0, node_type_2)]),
-  ));
-
-  assert_eq!(
-    archipelago.nav_data.get_type_index_costs().collect::<Vec<_>>(),
-    [(node_type_1, 2.0), (node_type_2, 3.0)]
-  );
-
-  // Two islands still reference `node_type_1`.
-  assert!(!archipelago.remove_node_type(node_type_1));
-  assert_eq!(
-    archipelago.nav_data.get_type_index_costs().collect::<Vec<_>>(),
-    [(node_type_1, 2.0), (node_type_2, 3.0)]
-  );
-
-  archipelago.remove_island(island_id_1);
-  // One island still references `node_type_1`.
-  assert!(!archipelago.remove_node_type(node_type_1));
-  assert_eq!(
-    archipelago.nav_data.get_type_index_costs().collect::<Vec<_>>(),
-    [(node_type_1, 2.0), (node_type_2, 3.0)]
-  );
-
-  archipelago.remove_island(island_id_2);
-  // Now we can delete it!
-  assert!(archipelago.remove_node_type(node_type_1));
-
-  // We can't delete it twice.
-  assert!(!archipelago.remove_node_type(node_type_1));
-
-  assert_eq!(
-    archipelago.nav_data.get_type_index_costs().collect::<Vec<_>>(),
-    [(node_type_2, 3.0)]
-  );
-}
-
-#[test]
-#[should_panic]
-fn panics_on_invalid_node_type() {
-  let mut archipelago =
-    Archipelago::<XY>::new(AgentOptions::from_agent_radius(0.5));
-  let deleted_node_type = archipelago.add_node_type(2.0).unwrap();
-  assert!(archipelago.remove_node_type(deleted_node_type));
-
-  let nav_mesh = Arc::new(
-    NavigationMesh {
-      vertices: vec![
-        Vec2::new(0.0, 0.0),
-        Vec2::new(1.0, 0.0),
-        Vec2::new(1.0, 1.0),
-        Vec2::new(0.0, 1.0),
-      ],
-      polygons: vec![vec![0, 1, 2, 3]],
-      polygon_type_indices: vec![0],
-      height_mesh: None,
-    }
-    .validate()
-    .expect("mesh is valid"),
-  );
-
-  archipelago.add_island(Island::new(
-    Transform::default(),
-    nav_mesh,
-    HashMap::from([(0, deleted_node_type)]),
-  ));
-
-  // Panics due to referencing invalid node type.
-  archipelago.update(1.0);
 }

--- a/crates/landmass/src/nav_data_test.rs
+++ b/crates/landmass/src/nav_data_test.rs
@@ -929,7 +929,7 @@ fn empty_navigation_mesh_is_safe() {
 }
 
 #[test]
-fn error_on_create_zero_or_negative_node_type() {
+fn error_on_set_zero_or_negative_type_index_cost() {
   let mut archipelago =
     Archipelago::<XY>::new(AgentOptions::from_agent_radius(0.5));
   assert_eq!(

--- a/crates/landmass/src/path_test.rs
+++ b/crates/landmass/src/path_test.rs
@@ -1,8 +1,4 @@
-use std::{
-  collections::{HashMap, HashSet},
-  f32::consts::PI,
-  sync::Arc,
-};
+use std::{collections::HashSet, f32::consts::PI, sync::Arc};
 
 use glam::{Vec2, Vec3};
 use slotmap::HopSlotMap;
@@ -76,11 +72,8 @@ fn finds_next_point_for_organic_map() {
     Transform { translation: Vec3::new(5.0, 9.0, 7.0), rotation: PI * -0.35 };
   let mut archipelago =
     Archipelago::<XYZ>::new(AgentOptions::from_agent_radius(0.5));
-  let island_id = archipelago.add_island(Island::new(
-    transform.clone(),
-    Arc::new(nav_mesh),
-    HashMap::new(),
-  ));
+  let island_id =
+    archipelago.add_island(Island::new(transform.clone(), Arc::new(nav_mesh)));
 
   let path = Path {
     island_segments: vec![IslandSegment {
@@ -180,11 +173,8 @@ fn finds_next_point_in_zig_zag() {
     Transform { translation: Vec2::new(-1.0, -3.0), rotation: PI * -1.8 };
   let mut archipelago =
     Archipelago::<XY>::new(AgentOptions::from_agent_radius(0.5));
-  let island_id = archipelago.add_island(Island::new(
-    transform.clone(),
-    Arc::new(nav_mesh),
-    HashMap::new(),
-  ));
+  let island_id =
+    archipelago.add_island(Island::new(transform.clone(), Arc::new(nav_mesh)));
 
   let path = Path {
     island_segments: vec![IslandSegment {
@@ -255,7 +245,6 @@ fn starts_at_end_index_goes_to_end_point() {
   let island_id = archipelago.add_island(Island::new(
     Transform { translation: Vec3::ZERO, rotation: 0.0 },
     Arc::new(nav_mesh),
-    HashMap::new(),
   ));
 
   let path = Path {

--- a/crates/landmass/src/pathfinding.rs
+++ b/crates/landmass/src/pathfinding.rs
@@ -27,9 +27,9 @@ struct ArchipelagoPathProblem<'a, CS: CoordinateSystem> {
   end_node: NodeRef,
   /// The center of the end_node. This is just a cached point for easy access.
   end_point: Vec3,
-  /// The cheapest node type cost in [`Self::nav_data`]. This is cached once
+  /// The cheapest type index cost in [`Self::nav_data`]. This is cached once
   /// since it is constant for the whole problem.
-  cheapest_node_type_cost: f32,
+  cheapest_type_index_cost: f32,
   /// Replacement costs for the `nav_data.type_index_to_cost`.
   override_type_index_to_cost: &'a HashMap<usize, f32>,
 }
@@ -223,7 +223,7 @@ impl<CS: CoordinateSystem> AStarProblem for ArchipelagoPathProblem<'_, CS> {
         boundary_link.portal.0.midpoint(boundary_link.portal.1)
       }
     };
-    world_point.distance(self.end_point) * self.cheapest_node_type_cost
+    world_point.distance(self.end_point) * self.cheapest_type_index_cost
   }
 
   fn is_goal_state(&self, state: &Self::StateType) -> bool {
@@ -262,7 +262,7 @@ pub(crate) fn find_path<CS: CoordinateSystem>(
     end_node,
     start_point,
     end_point,
-    cheapest_node_type_cost: *nav_data
+    cheapest_type_index_cost: *nav_data
       .get_type_index_costs()
       .map(|(type_index, cost)| {
         (

--- a/crates/landmass/src/query_test.rs
+++ b/crates/landmass/src/query_test.rs
@@ -193,7 +193,7 @@ fn samples_node_types() {
       /* point= */ offset + Vec2::new(0.5, 0.5),
       /* distance_to_node= */ &0.1
     )
-    .map(|p| p.node_type()),
+    .map(|p| p.type_index()),
     Ok(None)
   );
   assert_eq!(
@@ -202,7 +202,7 @@ fn samples_node_types() {
       /* point= */ offset + Vec2::new(1.5, 0.5),
       /* distance_to_node= */ &0.1
     )
-    .map(|p| p.node_type()),
+    .map(|p| p.type_index()),
     Ok(Some(node_type_1))
   );
   assert_eq!(
@@ -211,7 +211,7 @@ fn samples_node_types() {
       /* point= */ offset + Vec2::new(2.5, 0.5),
       /* distance_to_node= */ &0.1
     )
-    .map(|p| p.node_type()),
+    .map(|p| p.type_index()),
     Ok(Some(node_type_2))
   );
   assert_eq!(
@@ -220,7 +220,7 @@ fn samples_node_types() {
       /* point= */ offset + Vec2::new(3.5, 0.5),
       /* distance_to_node= */ &0.1
     )
-    .map(|p| p.node_type()),
+    .map(|p| p.type_index()),
     Ok(Some(node_type_3))
   );
 }
@@ -464,7 +464,7 @@ fn find_path_returns_error_on_invalid_node_cost() {
       &end_point,
       &HashMap::from([(node_type, 0.0)]),
     ),
-    Err(FindPathError::NonPositiveNodeTypeCost(node_type, 0.0))
+    Err(FindPathError::NonPositiveTypeIndexCost(node_type, 0.0))
   );
   assert_eq!(
     find_path(
@@ -473,7 +473,7 @@ fn find_path_returns_error_on_invalid_node_cost() {
       &end_point,
       &HashMap::from([(node_type, -0.5)]),
     ),
-    Err(FindPathError::NonPositiveNodeTypeCost(node_type, -0.5))
+    Err(FindPathError::NonPositiveTypeIndexCost(node_type, -0.5))
   );
 }
 

--- a/crates/landmass/src/query_test.rs
+++ b/crates/landmass/src/query_test.rs
@@ -135,7 +135,7 @@ fn samples_point_on_nav_mesh_or_near_nav_mesh() {
 }
 
 #[test]
-fn samples_node_types() {
+fn samples_type_indices() {
   let mut archipelago =
     Archipelago::<XY>::new(AgentOptions::from_agent_radius(0.5));
 
@@ -312,7 +312,7 @@ fn finds_path() {
 }
 
 #[test]
-fn finds_path_with_override_node_types() {
+fn finds_path_with_override_type_index_costs() {
   let mut archipelago =
     Archipelago::<XY>::new(AgentOptions::from_agent_radius(0.5));
 


### PR DESCRIPTION
Previously, nav meshes had a type index for each polygon, which then got translated into a node type (which could only be created on the archipelago), which then got translated into the final cost. This was a pain in the neck to deal with, since you couldn't just load up a nav mesh, you had to "glue" it with the correct node types.

In practice, users are likely going to be good enough enforcing the semantics of each type index (e.g., 1 is grass, 2 is road, 3 is quicksand). Then the API on the users is much simpler - just specify the cost of each type index! This can even be done at load time very easily.

In practice, navigation systems in other engines just use a simple integer to represent the different areas (though usually this is represented as an enum that can be configured).