### PR TITLE
Decrease the default avoidance time horizons.

### DIFF
--- a/crates/landmass/README.md
+++ b/crates/landmass/README.md
@@ -107,7 +107,7 @@ let agent_2 = archipelago.add_agent({
   agent
 });
 
-for i in 0..200 {
+for i in 0..300 {
   let delta_time = 1.0 / 10.0;
   archipelago.update(delta_time);
 

--- a/crates/landmass/src/lib.rs
+++ b/crates/landmass/src/lib.rs
@@ -85,8 +85,8 @@ impl<CS: CoordinateSystem<SampleDistance: FromAgentRadius>> FromAgentRadius
     Self {
       point_sample_distance: CS::SampleDistance::from_agent_radius(radius),
       neighbourhood: 10.0 * radius,
-      avoidance_time_horizon: 1.0,
-      obstacle_avoidance_time_horizon: 0.5,
+      avoidance_time_horizon: 0.5,
+      obstacle_avoidance_time_horizon: 0.25,
       reached_destination_avoidance_responsibility: 0.1,
     }
   }


### PR DESCRIPTION
Too high values can result in agents taking strange paths when a more direct path is valid. This is visible in the playground example, so it seems like it would happen commonly.

Agents still take slightly strange paths, but much less so!