### PR TITLE
Bump the version of landmass to 0.9.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 ### Migration Guide
 
+## `landmass` 0.9.1 - 2025-10-20
+
+### Fixes
+
+- Changing an island will now correctly update bidirectional animation links where the end is a
+  point.
+
 ## `landmass` 0.9.0 / `bevy_landmass` 0.10.0 - 2025-10-01
 
 ### Features

--- a/crates/landmass/Cargo.toml
+++ b/crates/landmass/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2024"
 name = "landmass"
-version = "0.9.0"
+version = "0.9.1"
 
 description = "A navigation system for video game characters to walk around levels."
 


### PR DESCRIPTION
This is to include the fix of the animation links if changing the islands but not the links.