### PR TITLE
Upgrade-Bevy 0.18.0

### DIFF
--- a/crates/bevy_landmass/Cargo.toml
+++ b/crates/bevy_landmass/Cargo.toml
@@ -21,21 +21,21 @@ type_complexity = "allow"
 [dependencies]
 landmass = { path = "../landmass", version = "0.9.0", default-features = false }
 
-bevy_app = { version = "0.17", default-features = false }
-bevy_asset = { version = "0.17", default-features = false }
-bevy_color = { version = "0.17", default-features = false }
-bevy_ecs = { version = "0.17", default-features = false }
-bevy_gizmos = { version = "0.17", default-features = false }
-bevy_log = { version = "0.17", default-features = false }
-bevy_math = { version = "0.17", default-features = false }
-bevy_mesh = { version = "0.17", optional = true, default-features = false }
-bevy_platform = { version = "0.17", default-features = false }
-bevy_reflect = { version = "0.17", default-features = false }
-bevy_time = { version = "0.17", default-features = false }
-bevy_transform = { version = "0.17", default-features = false }
+bevy_app = { version = "0.18", default-features = false }
+bevy_asset = { version = "0.18", default-features = false }
+bevy_color = { version = "0.18", default-features = false }
+bevy_ecs = { version = "0.18", default-features = false }
+bevy_gizmos = { version = "0.18", default-features = false }
+bevy_log = { version = "0.18", default-features = false }
+bevy_math = { version = "0.18", default-features = false }
+bevy_mesh = { version = "0.18", optional = true, default-features = false }
+bevy_platform = { version = "0.18", default-features = false }
+bevy_reflect = { version = "0.18", default-features = false }
+bevy_time = { version = "0.18", default-features = false }
+bevy_transform = { version = "0.18", default-features = false }
 
 [dev-dependencies]
-bevy = "0.17"
+bevy = "0.18"
 googletest = "0.14.2"
 
 [features]

--- a/crates/bevy_landmass/src/debug.rs
+++ b/crates/bevy_landmass/src/debug.rs
@@ -482,7 +482,7 @@ impl<CS: CoordinateSystem> DebugDrawer<CS> for GizmoDrawer<'_, '_, '_, CS> {
       };
       let line =
         [CS::to_world_position(&line[0]), CS::to_world_position(&line[1])];
-      self.cuboid(
+      self.cube(
         Transform::default()
           .looking_to(line[1] - line[0], bevy_math::Vec3::new(0.0, 1.0, 0.0))
           .with_translation((line[0] + line[1]) * 0.5)

--- a/crates/landmass_rerecast/Cargo.toml
+++ b/crates/landmass_rerecast/Cargo.toml
@@ -16,17 +16,17 @@ keywords = ["navigation", "system", "pathfinding"]
 [dependencies]
 bevy_landmass = { version = "0.10", path = "../bevy_landmass", default-features = false }
 
-bevy_app = { version = "0.17", default-features = false }
-bevy_asset = { version = "0.17", default-features = false }
-bevy_ecs = { version = "0.17", default-features = false }
-bevy_log = { version = "0.17", default-features = false }
-bevy_math = { version = "0.17", default-features = false }
-bevy_platform = { version = "0.17", default-features = false }
+bevy_app = { version = "0.18", default-features = false }
+bevy_asset = { version = "0.18", default-features = false }
+bevy_ecs = { version = "0.18", default-features = false }
+bevy_log = { version = "0.18", default-features = false }
+bevy_math = { version = "0.18", default-features = false }
+bevy_platform = { version = "0.18", default-features = false }
 
 bevy_rerecast = { version = "0.3", default-features = false }
 
 [dev-dependencies]
-bevy = "0.17"
+bevy = "0.18"
 googletest = "0.14.2"
 bevy_rerecast = { version = "0.3", default-features = false, features = [
     "bevy_mesh",


### PR DESCRIPTION
Change dependencies of
- Bevy_landmace
- landmass_rerecast

FIX Error
- cuboid to cube

Warnings ignored