### PR TITLE
Bevy 0.18

### DIFF
--- a/crates/bevy_landmass/Cargo.toml
+++ b/crates/bevy_landmass/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_landmass"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 
 description = "A plugin for Bevy to handle navigation of AI characters."
@@ -21,21 +21,21 @@ type_complexity = "allow"
 [dependencies]
 landmass = { path = "../landmass", version = "0.9.0", default-features = false }
 
-bevy_app = { version = "0.17", default-features = false }
-bevy_asset = { version = "0.17", default-features = false }
-bevy_color = { version = "0.17", default-features = false }
-bevy_ecs = { version = "0.17", default-features = false }
-bevy_gizmos = { version = "0.17", default-features = false }
-bevy_log = { version = "0.17", default-features = false }
-bevy_math = { version = "0.17", default-features = false }
-bevy_mesh = { version = "0.17", optional = true, default-features = false }
-bevy_platform = { version = "0.17", default-features = false }
-bevy_reflect = { version = "0.17", default-features = false }
-bevy_time = { version = "0.17", default-features = false }
-bevy_transform = { version = "0.17", default-features = false }
+bevy_app = { version = "0.18", default-features = false }
+bevy_asset = { version = "0.18", default-features = false }
+bevy_color = { version = "0.18", default-features = false }
+bevy_ecs = { version = "0.18", default-features = false }
+bevy_gizmos = { version = "0.18", default-features = false }
+bevy_log = { version = "0.18", default-features = false }
+bevy_math = { version = "0.18", default-features = false }
+bevy_mesh = { version = "0.18", optional = true, default-features = false }
+bevy_platform = { version = "0.18", default-features = false }
+bevy_reflect = { version = "0.18", default-features = false }
+bevy_time = { version = "0.18", default-features = false }
+bevy_transform = { version = "0.18", default-features = false }
 
 [dev-dependencies]
-bevy = "0.17"
+bevy = "0.18"
 googletest = "0.14.2"
 
 [features]

--- a/crates/bevy_landmass/src/agent.rs
+++ b/crates/bevy_landmass/src/agent.rs
@@ -103,8 +103,9 @@ impl AgentTypeIndexCostOverrides {
 ///   }
 /// }
 /// ```
-#[derive(Component)]
+#[derive(Component, Default)]
 pub enum AgentTarget<CS: CoordinateSystem> {
+  #[default]
   None,
   Point(CS::Coordinate),
   Entity(Entity),
@@ -112,12 +113,6 @@ pub enum AgentTarget<CS: CoordinateSystem> {
 
 pub type AgentTarget2d = AgentTarget<TwoD>;
 pub type AgentTarget3d = AgentTarget<ThreeD>;
-
-impl<CS: CoordinateSystem> Default for AgentTarget<CS> {
-  fn default() -> Self {
-    Self::None
-  }
-}
 
 impl<CS: CoordinateSystem<Coordinate: std::fmt::Debug>> std::fmt::Debug
   for AgentTarget<CS>

--- a/crates/bevy_landmass/src/debug.rs
+++ b/crates/bevy_landmass/src/debug.rs
@@ -482,7 +482,7 @@ impl<CS: CoordinateSystem> DebugDrawer<CS> for GizmoDrawer<'_, '_, '_, CS> {
       };
       let line =
         [CS::to_world_position(&line[0]), CS::to_world_position(&line[1])];
-      self.cuboid(
+      self.cube(
         Transform::default()
           .looking_to(line[1] - line[0], bevy_math::Vec3::new(0.0, 1.0, 0.0))
           .with_translation((line[0] + line[1]) * 0.5)

--- a/crates/landmass/src/agent_test.rs
+++ b/crates/landmass/src/agent_test.rs
@@ -2,7 +2,7 @@ use std::{collections::HashSet, f32::consts::PI, sync::Arc};
 
 use glam::{Vec2, Vec3};
 use googletest::{expect_that, expect_true, matchers::*};
-use slotmap::HopSlotMap;
+use slotmap::SlotMap;
 
 use crate::{
   Agent, Archipelago, ArchipelagoOptions, CoordinateSystem, FromAgentRadius,
@@ -642,7 +642,7 @@ fn clears_path_for_missing_nodes() {
   agent.current_target = Some(Vec3::ZERO);
 
   // Create an unused slotmap just to get `IslandId`s.
-  let mut slotmap = HopSlotMap::<IslandId, _>::with_key();
+  let mut slotmap = SlotMap::<IslandId, _>::with_key();
   let island_id = slotmap.insert(0);
 
   assert_eq!(
@@ -680,7 +680,7 @@ fn repaths_for_invalid_path_or_nodes_off_path() {
   agent.current_target = Some(Vec3::ZERO);
 
   // Create an unused slotmap just to get `IslandId`s.
-  let mut slotmap = HopSlotMap::<IslandId, _>::with_key();
+  let mut slotmap = SlotMap::<IslandId, _>::with_key();
   let island_id = slotmap.insert(0);
   let missing_island_id = slotmap.insert(0);
 

--- a/crates/landmass/src/avoidance.rs
+++ b/crates/landmass/src/avoidance.rs
@@ -3,7 +3,7 @@ use std::collections::{BinaryHeap, HashMap, HashSet};
 use dodgy_2d::VisibilitySet;
 use glam::{Vec3, Vec3Swizzles};
 use kdtree::{KdTree, distance::squared_euclidean};
-use slotmap::HopSlotMap;
+use slotmap::DenseSlotMap;
 
 use crate::{
   Agent, AgentId, AgentState, ArchipelagoOptions, Character, CharacterId,
@@ -14,9 +14,9 @@ use crate::{
 /// Adjusts the velocity of `agents` to apply local avoidance. `delta_time` must
 /// be positive.
 pub(crate) fn apply_avoidance_to_agents<CS: CoordinateSystem>(
-  agents: &mut HopSlotMap<AgentId, Agent<CS>>,
+  agents: &mut DenseSlotMap<AgentId, Agent<CS>>,
   agent_id_to_agent_node: &HashMap<AgentId, (Vec3, NodeRef)>,
-  characters: &HopSlotMap<CharacterId, Character<CS>>,
+  characters: &DenseSlotMap<CharacterId, Character<CS>>,
   character_id_to_nav_mesh_point: &HashMap<CharacterId, Vec3>,
   nav_data: &NavigationData<CS>,
   agent_options: &ArchipelagoOptions<CS>,

--- a/crates/landmass/src/avoidance_test.rs
+++ b/crates/landmass/src/avoidance_test.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use glam::{Vec2, Vec3};
-use slotmap::HopSlotMap;
+use slotmap::DenseSlotMap;
 
 use crate::{
   Agent, AgentId, Archipelago, ArchipelagoOptions, Character, CharacterId,
@@ -408,7 +408,7 @@ fn applies_no_avoidance_for_far_agents() {
     Arc::new(nav_mesh),
   ));
 
-  let mut agents = HopSlotMap::<AgentId, _>::with_key();
+  let mut agents = DenseSlotMap::<AgentId, _>::with_key();
   let agent_1 = agents.insert({
     let mut agent = Agent::create(
       /* position= */ Vec3::new(1.0, 1.0, 0.0),
@@ -463,7 +463,7 @@ fn applies_no_avoidance_for_far_agents() {
   apply_avoidance_to_agents(
     &mut agents,
     &agent_id_to_agent_node,
-    /* characters= */ &HopSlotMap::with_key(),
+    /* characters= */ &DenseSlotMap::with_key(),
     /* character_id_to_nav_mesh_point= */ &HashMap::new(),
     &nav_data,
     &ArchipelagoOptions {
@@ -509,7 +509,7 @@ fn applies_avoidance_for_two_agents() {
     Arc::new(nav_mesh),
   ));
 
-  let mut agents = HopSlotMap::<AgentId, _>::with_key();
+  let mut agents = DenseSlotMap::<AgentId, _>::with_key();
   let agent_1 = agents.insert({
     let mut agent = Agent::create(
       /* position= */ Vec3::new(1.0, 1.0, 0.0),
@@ -552,7 +552,7 @@ fn applies_avoidance_for_two_agents() {
   apply_avoidance_to_agents(
     &mut agents,
     &agent_id_to_agent_node,
-    /* characters= */ &HopSlotMap::with_key(),
+    /* characters= */ &DenseSlotMap::with_key(),
     /* character_id_to_nav_mesh_point= */ &HashMap::new(),
     &nav_data,
     &ArchipelagoOptions {
@@ -604,7 +604,7 @@ fn agent_avoids_character() {
     Arc::new(nav_mesh),
   ));
 
-  let mut agents = HopSlotMap::<AgentId, _>::with_key();
+  let mut agents = DenseSlotMap::<AgentId, _>::with_key();
   let agent = agents.insert({
     let mut agent = Agent::create(
       /* position= */ Vec3::new(1.0, 1.0, 0.0),
@@ -616,7 +616,7 @@ fn agent_avoids_character() {
     agent.current_desired_move = Vec3::new(1.0, 0.0, 0.0);
     agent
   });
-  let mut characters = HopSlotMap::<CharacterId, _>::with_key();
+  let mut characters = DenseSlotMap::<CharacterId, _>::with_key();
   let character = characters.insert(Character {
     position: Vec3::new(11.0, 1.01, 0.0),
     velocity: Vec3::new(-1.0, 0.0, 0.0),
@@ -686,7 +686,7 @@ fn agent_speeds_up_to_avoid_character() {
     Arc::new(nav_mesh),
   ));
 
-  let mut agents = HopSlotMap::<AgentId, _>::with_key();
+  let mut agents = DenseSlotMap::<AgentId, _>::with_key();
   let agent = agents.insert({
     let mut agent = Agent::<XY>::create(
       /* position= */ Vec2::new(5.0, 0.0),
@@ -711,7 +711,7 @@ fn agent_speeds_up_to_avoid_character() {
   apply_avoidance_to_agents(
     &mut agents,
     &agent_id_to_agent_node,
-    &HopSlotMap::with_key(),
+    &DenseSlotMap::with_key(),
     &HashMap::new(),
     &nav_data,
     &ArchipelagoOptions {
@@ -727,7 +727,7 @@ fn agent_speeds_up_to_avoid_character() {
     Vec2::new(1.0, 0.0)
   );
 
-  let mut characters = HopSlotMap::<CharacterId, _>::with_key();
+  let mut characters = DenseSlotMap::<CharacterId, _>::with_key();
   let character = characters.insert(Character::<XY> {
     // Just slightly closer to the agent so it prefers to "speed up".
     position: Vec2::new(0.0, 5.0),

--- a/crates/landmass/src/lib.rs
+++ b/crates/landmass/src/lib.rs
@@ -18,7 +18,7 @@ mod util;
 use agent::{RepathResult, does_agent_need_repath};
 use glam::Vec3Swizzles;
 use path::PathIndex;
-use slotmap::HopSlotMap;
+use slotmap::DenseSlotMap;
 use std::collections::HashMap;
 
 use nav_data::NavigationData;
@@ -54,8 +54,8 @@ use crate::{
 pub struct Archipelago<CS: CoordinateSystem> {
   pub archipelago_options: ArchipelagoOptions<CS>,
   nav_data: NavigationData<CS>,
-  agents: HopSlotMap<AgentId, Agent<CS>>,
-  characters: HopSlotMap<CharacterId, Character<CS>>,
+  agents: DenseSlotMap<AgentId, Agent<CS>>,
+  characters: DenseSlotMap<CharacterId, Character<CS>>,
   pathing_results: Vec<PathingResult>,
 }
 
@@ -97,8 +97,8 @@ impl<CS: CoordinateSystem> Archipelago<CS> {
     Self {
       archipelago_options,
       nav_data: NavigationData::new(),
-      agents: HopSlotMap::with_key(),
-      characters: HopSlotMap::with_key(),
+      agents: DenseSlotMap::with_key(),
+      characters: DenseSlotMap::with_key(),
       pathing_results: Vec::new(),
     }
   }

--- a/crates/landmass/src/nav_data.rs
+++ b/crates/landmass/src/nav_data.rs
@@ -9,7 +9,7 @@ use disjoint::DisjointSet;
 use geo::{BooleanOps, Coord, LineString, LinesIter, MultiPolygon, Polygon};
 use glam::{Vec2, Vec3, Vec3Swizzles};
 use kdtree::{KdTree, distance::squared_euclidean};
-use slotmap::{HopSlotMap, SlotMap, new_key_type};
+use slotmap::{DenseSlotMap, SlotMap, new_key_type};
 use thiserror::Error;
 
 use crate::{
@@ -26,9 +26,9 @@ use crate::{
 /// "static" features.
 pub(crate) struct NavigationData<CS: CoordinateSystem> {
   /// The islands in the [`crate::Archipelago`].
-  islands: HopSlotMap<IslandId, Island<CS>>,
+  islands: DenseSlotMap<IslandId, Island<CS>>,
   /// The animation links in the [`crate::AnimationLink`].
-  animation_links: HopSlotMap<AnimationLinkId, AnimationLinkState<CS>>,
+  animation_links: DenseSlotMap<AnimationLinkId, AnimationLinkState<CS>>,
   /// The "default" cost of each type index. Missing type indices default to a
   /// cost of 1.0.
   type_index_to_cost: HashMap<usize, f32>,
@@ -144,8 +144,8 @@ impl<CS: CoordinateSystem> NavigationData<CS> {
   /// Creates new navigation data.
   pub(crate) fn new() -> Self {
     Self {
-      islands: HopSlotMap::with_key(),
-      animation_links: HopSlotMap::with_key(),
+      islands: DenseSlotMap::with_key(),
+      animation_links: DenseSlotMap::with_key(),
       type_index_to_cost: HashMap::new(),
       // The navigation data is empty, so there's nothing to update (so not
       // dirty).
@@ -535,7 +535,7 @@ impl<CS: CoordinateSystem> NavigationData<CS> {
       end_edge: (Vec3, Vec3),
       animation_link_id: AnimationLinkId,
       link: &AnimationLink<CS>,
-      islands: &HopSlotMap<IslandId, Island<CS>>,
+      islands: &DenseSlotMap<IslandId, Island<CS>>,
       off_mesh_links: &mut SlotMap<OffMeshLinkId, OffMeshLink>,
       node_to_off_mesh_link_ids: &mut HashMap<NodeRef, HashSet<OffMeshLinkId>>,
     ) {
@@ -1334,7 +1334,7 @@ fn link_edges_between_islands<CS: CoordinateSystem>(
 fn world_portal_to_node_portals<CS: CoordinateSystem>(
   portal: (Vec3, Vec3),
   island_bbh: &BoundingBoxHierarchy<IslandId>,
-  islands: &HopSlotMap<IslandId, Island<CS>>,
+  islands: &DenseSlotMap<IslandId, Island<CS>>,
   island_to_node_bbh: &mut HashMap<IslandId, BoundingBoxHierarchy<usize>>,
   max_vertical_distance: f32,
 ) -> Vec<NodePortal> {
@@ -1390,7 +1390,7 @@ fn world_portal_to_node_portals<CS: CoordinateSystem>(
 fn sample_animation_link_point<CS: CoordinateSystem>(
   point: Vec3,
   island_bbh: &BoundingBoxHierarchy<IslandId>,
-  islands: &HopSlotMap<IslandId, Island<CS>>,
+  islands: &DenseSlotMap<IslandId, Island<CS>>,
   max_vertical_distance: f32,
 ) -> Option<NodeRef> {
   let query_box = BoundingBox::new_box(

--- a/crates/landmass/src/nav_data_test.rs
+++ b/crates/landmass/src/nav_data_test.rs
@@ -10,7 +10,7 @@ use googletest::{
   expect_eq, expect_false, expect_that, expect_true, matchers::*,
   prelude::container_eq,
 };
-use slotmap::{HopSlotMap, SlotMap};
+use slotmap::{DenseSlotMap, SlotMap};
 
 use crate::{
   Archipelago, ArchipelagoOptions, CoordinateSystem, FromAgentRadius,
@@ -240,7 +240,7 @@ fn link_edges_between_islands_links_touching_islands() {
   );
 
   // Create unused slotmaps just to get `IslandId`s and `NodeType`s.
-  let mut slotmap = HopSlotMap::<IslandId, _>::with_key();
+  let mut slotmap = DenseSlotMap::<IslandId, _>::with_key();
   let island_1_id = slotmap.insert(0);
   let island_2_id = slotmap.insert(0);
 

--- a/crates/landmass/src/path_test.rs
+++ b/crates/landmass/src/path_test.rs
@@ -2,7 +2,7 @@ use std::{collections::HashSet, f32::consts::PI, sync::Arc};
 
 use glam::{Vec2, Vec3};
 use googletest::{expect_that, matchers::*};
-use slotmap::HopSlotMap;
+use slotmap::DenseSlotMap;
 
 use crate::{
   Archipelago, ArchipelagoOptions, CoordinateSystem, FromAgentRadius, Island,
@@ -842,11 +842,11 @@ fn end_point_after_animation_link_is_reported() {
 #[test]
 fn path_not_valid_for_invalidated_islands_or_off_mesh_links() {
   // Create unused slotmaps just to get `IslandId`s and `OffMeshLinkId`s.
-  let mut slotmap = HopSlotMap::<IslandId, _>::with_key();
+  let mut slotmap = DenseSlotMap::<IslandId, _>::with_key();
   let island_id_1 = slotmap.insert(0);
   let island_id_2 = slotmap.insert(0);
   let island_id_3 = slotmap.insert(0);
-  let mut slotmap = HopSlotMap::<OffMeshLinkId, _>::with_key();
+  let mut slotmap = DenseSlotMap::<OffMeshLinkId, _>::with_key();
   let boundary_link_id_1 = slotmap.insert(0);
   let boundary_link_id_2 = slotmap.insert(0);
 
@@ -919,12 +919,12 @@ fn path_not_valid_for_invalidated_islands_or_off_mesh_links() {
 #[test]
 fn indices_in_path_are_found() {
   // Create unused slotmaps just to get `IslandId`s and `BoundaryLinkId`s.
-  let mut slotmap = HopSlotMap::<IslandId, _>::with_key();
+  let mut slotmap = DenseSlotMap::<IslandId, _>::with_key();
   let island_id_1 = slotmap.insert(0);
   let island_id_2 = slotmap.insert(0);
   let island_id_3 = slotmap.insert(0);
   let island_id_4 = slotmap.insert(0);
-  let mut slotmap = HopSlotMap::<OffMeshLinkId, _>::with_key();
+  let mut slotmap = DenseSlotMap::<OffMeshLinkId, _>::with_key();
   let boundary_link_id_1 = slotmap.insert(0);
   let boundary_link_id_2 = slotmap.insert(0);
 
@@ -999,12 +999,12 @@ fn indices_in_path_are_found() {
 #[test]
 fn indices_in_path_are_found_rev() {
   // Create unused slotmaps just to get `IslandId`s and `BoundaryLinkId`s.
-  let mut slotmap = HopSlotMap::<IslandId, _>::with_key();
+  let mut slotmap = DenseSlotMap::<IslandId, _>::with_key();
   let island_id_1 = slotmap.insert(0);
   let island_id_2 = slotmap.insert(0);
   let island_id_3 = slotmap.insert(0);
   let island_id_4 = slotmap.insert(0);
-  let mut slotmap = HopSlotMap::<OffMeshLinkId, _>::with_key();
+  let mut slotmap = DenseSlotMap::<OffMeshLinkId, _>::with_key();
   let boundary_link_id_1 = slotmap.insert(0);
   let boundary_link_id_2 = slotmap.insert(0);
 

--- a/crates/landmass_rerecast/Cargo.toml
+++ b/crates/landmass_rerecast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "landmass_rerecast"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 
 description = "An integration to allow use of rerecast navigation meshes in landmass."
@@ -14,20 +14,20 @@ categories = ["game-development"]
 keywords = ["navigation", "system", "pathfinding"]
 
 [dependencies]
-bevy_landmass = { version = "0.10", path = "../bevy_landmass", default-features = false }
+bevy_landmass = { version = "0.11", path = "../bevy_landmass", default-features = false }
 
-bevy_app = { version = "0.17", default-features = false }
-bevy_asset = { version = "0.17", default-features = false }
-bevy_ecs = { version = "0.17", default-features = false }
-bevy_log = { version = "0.17", default-features = false }
-bevy_math = { version = "0.17", default-features = false }
-bevy_platform = { version = "0.17", default-features = false }
+bevy_app = { version = "0.18", default-features = false }
+bevy_asset = { version = "0.18", default-features = false }
+bevy_ecs = { version = "0.18", default-features = false }
+bevy_log = { version = "0.18", default-features = false }
+bevy_math = { version = "0.18", default-features = false }
+bevy_platform = { version = "0.18", default-features = false }
 
-bevy_rerecast = { version = "0.3", default-features = false }
+bevy_rerecast = { version = "0.4", default-features = false }
 
 [dev-dependencies]
-bevy = "0.17"
+bevy = "0.18"
 googletest = "0.14.2"
-bevy_rerecast = { version = "0.3", default-features = false, features = [
+bevy_rerecast = { version = "0.4", default-features = false, features = [
     "bevy_mesh",
 ] }

--- a/crates/landmass_rerecast/README.md
+++ b/crates/landmass_rerecast/README.md
@@ -106,7 +106,7 @@ fn setup(
 
 // All the stuff below here is just to allow the doc tests to pass.
 
-fn check_after_navmesh_ready(_: Trigger<NavmeshReady>, mut commands: Commands) {
+fn check_after_navmesh_ready(_: On<NavmeshReady>, mut commands: Commands) {
   // Allow checking three times before failure, in case we need an extra frame
   // for the meshes to propagate.
   commands.insert_resource(CheckCounter(3));
@@ -118,7 +118,7 @@ struct CheckCounter(usize);
 fn check_for_path_and_exit(
   agent: Single<(&AgentState, &AgentDesiredVelocity3d)>,
   mut check_counter: ResMut<CheckCounter>,
-  mut exit: EventWriter<AppExit>,
+  mut exit: MessageWriter<AppExit>,
 ) {
   let (state, desired_velocity) = *agent;
 


### PR DESCRIPTION
Like https://github.com/andriyDev/landmass/pull/182, but includes rerecast update too :) Then I noticed that `clippy` was not happy, so I fixed that too!
Notably, `HopSlotMap` is deprecated, so I replaced it with `DenseSlotMap`, thinking that iteration speed is more important to us than random access.